### PR TITLE
Make HAL-traits toggleable and add modular CMakeLists build system for use with Zephyr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,17 +51,7 @@ jobs:
         run: pio test -e unittest
 
       - name: Find and run examples
-        run: |
-          EXAMPLES=$(find ./examples -name "*.cpp") # Find all examples
-          BUILD_DIR="./build" # it seems that without setting the --build-dir flag, the --keep-build-dir flag doesnt work
-          for example in $EXAMPLES; do # Loop through each example and build/run
-            echo "Building and running $example"
-            platformio ci "$example" --lib src --project-conf platformio.ini --keep-build-dir --build-dir $BUILD_DIR
-            rm $BUILD_DIR/src/*.cpp # if not removed, multiple definitions of main will be left behind
-          done
-          rm -rf $BUILD_DIR # clean up
-        env:
-          PLATFORMIO_BUILD_CACHE_DIR: .pio/build_cache
+        run: sh ./examples/build.sh
 
   linter:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Install PlatformIO
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade platformio
+          pip install platformio==6.1.16
+          pio --version
 
       - name: Build
         run: pio run

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+# It is assumed this script lives in the repository root folder called examples
+OD="$(pwd)" # original directory
+SD="$(dirname "$(realpath "$0")")" # script directory
+RD="$SD/.." # root directory
+D="$RD/build_examples" # build directory
+trap "[ -d $D ] && rm -rf $D; cd $OD" EXIT INT TERM HUP QUIT
+
+export PLATFORMIO_BUILD_CACHE_DIR="$RD/.pio/build_cache"
+
+cd $RD
+# The only reason 'pio ci' is called with '--keep-build-dir' is because we need zephyr/prj.conf to be present at build
+for example_file in $(find examples -type f -name "*.cpp"); do
+    echo "--- TESTING: $example_file"
+    mkdir $D
+    cp -ar "./zephyr" $D/
+    pio ci $example_file --lib src --build-dir $D --keep-build-dir --project-conf platformio.ini "$@"
+    rm -rf $D
+done

--- a/examples/core/debugging.cpp
+++ b/examples/core/debugging.cpp
@@ -3,10 +3,10 @@
 int main() {
     using namespace spn::core;
 
-    DBG("This is a debug messagee. Used to signal internal behaviour to a developer. It only prints when the "
-        "preprocessor `SPINE_DEBUG` is set during build");
+    SPN_DBG("This is a debug messagee. Used to signal internal behaviour to a developer. It only prints when the "
+            "preprocessor `SPINE_DEBUG` is set during build");
 
-    assert(true); // if condition is not met, an exception will be raised. See exception.cpp for further details.
-    expect(true); // if condition is not met, an error will be logged.
+    spn_assert(true); // if condition is not met, an exception will be raised. See exception.cpp for further details.
+    spn_expect(true); // if condition is not met, an error will be logged.
     return 0;
 }

--- a/examples/core/exception.cpp
+++ b/examples/core/exception.cpp
@@ -17,7 +17,7 @@ int main() {
 
     set_machine_exception_handler(std::make_unique<MyExceptionHandler>()); // set the machine's global exception handler
 
-    assert(false); // when this assertion fails, an exception will be raised. The machine's exception handler will then
+    spn_assert(false); // when this assertion fails, an exception will be raised. The machine's exception handler will then
                    // be called
 
     return 0;

--- a/examples/core/exception.cpp
+++ b/examples/core/exception.cpp
@@ -10,7 +10,7 @@ int main() {
         MyExceptionHandler() {}
 
         void handle_exception(const spn::core::Exception& exception) override {
-            ERR("MyExceptionHandler: Handling exception: %s", exception.error_type());
+            SPN_ERR("MyExceptionHandler: Handling exception: %s", exception.error_type());
             // perform a safe shutdown
         }
     };

--- a/examples/core/logging.cpp
+++ b/examples/core/logging.cpp
@@ -14,11 +14,11 @@ int main() {
     [[maybe_unused]] auto warnings_are_logged = is_loggable(LogLevel::WARN); // check if a particular level is enabled
     [[maybe_unused]] auto logging_level = log_level(); // get the current logging level
 
-    LOG("This is an information message. Used to signal events to a user that should be trackable in the logs")
-    WARN("This is a warning message. Used to signal abnormal behaviour to a user that is to be expected");
-    ERR("This is an error message. Used to signal erroneous behaviour to a user that should ideally not occur at all")
+    SPN_LOG("This is an information message. Used to signal events to a user that should be trackable in the logs")
+    SPN_WARN("This is a warning message. Used to signal abnormal behaviour to a user that is to be expected");
+    SPN_ERR("This is an error message. Used to signal erroneous behaviour to a user that should ideally not occur at all")
 
-    // See examples/core/debugging.cpp for the DBG macro that prints when SPINE_DEBUG is defined
+    // See examples/core/debugging.cpp for the SPN_DBG macro that prints when SPINE_DEBUG is defined
 
     return 0;
 }

--- a/examples/structure/result.cpp
+++ b/examples/structure/result.cpp
@@ -21,20 +21,20 @@ int main() {
     Result<int, ErrorCode> success_result(10);
     Result<int, ErrorCode> error_result = Result<int, ErrorCode>::failed(ErrorCode::SomethingWentWrong);
 
-    if (success_result.is_success()) DBG("Success result value: %d\n", success_result.value());
-    if (error_result.is_failed()) DBG("Error result: %s\n", error_code_to_string(error_result.error_value()));
+    if (success_result.is_success()) SPN_DBG("Success result value: %d\n", success_result.value());
+    if (error_result.is_failed()) SPN_DBG("Error result: %s\n", error_code_to_string(error_result.error_value()));
 
     // Example: Intermediary state handling using ErrorCode
     Result<int, ErrorCode, int> intermediary_result = Result<int, ErrorCode, int>::intermediary(5);
 
     if (intermediary_result.is_intermediary())
-        DBG("Intermediary result value: %d\n", intermediary_result.intermediary_value());
+        SPN_DBG("Intermediary result value: %d\n", intermediary_result.intermediary_value());
 
     // Example: Using map to transform success value
     auto mapped_result = success_result.map([](const int& value) {
         return value * 2; // Doubles the success value
     });
-    if (mapped_result.is_success()) DBG("Mapped success value: %d\n", mapped_result.value());
+    if (mapped_result.is_success()) SPN_DBG("Mapped success value: %d\n", mapped_result.value());
 
     // Example: Using map_error to transform error value (modify error codes if needed)
     auto mapped_error_result = error_result.map_error([](ErrorCode err) {
@@ -42,21 +42,21 @@ int main() {
         return ErrorCode::SomethingWentWrong;
     });
     if (mapped_error_result.is_failed())
-        DBG("Mapped error result: %s\n", error_code_to_string(mapped_error_result.error_value()));
+        SPN_DBG("Mapped error result: %s\n", error_code_to_string(mapped_error_result.error_value()));
 
     // Example: Chaining operations with and_then
     auto chained_result = success_result.and_then([](const int& value) -> Result<int, ErrorCode> {
         if (value > 5) return Result<int, ErrorCode>(value * 3); // Transform if success
         return Result<int, ErrorCode>::failed(ErrorCode::ValueTooSmall);
     });
-    if (chained_result.is_success()) DBG("Chained result success: %d\n", chained_result.value());
+    if (chained_result.is_success()) SPN_DBG("Chained result success: %d\n", chained_result.value());
 
     // Example: Using or_else to handle error and provide a fallback
     auto recovered_result = error_result.or_else([](ErrorCode err) -> Result<int, ErrorCode> {
-        DBG("Recovering from error: %s\n", error_code_to_string(err));
+        SPN_DBG("Recovering from error: %s\n", error_code_to_string(err));
         return Result<int, ErrorCode>(42); // Provide a fallback success value
     });
-    if (recovered_result.is_success()) DBG("Recovered result success: %d\n", recovered_result.value());
+    if (recovered_result.is_success()) SPN_DBG("Recovered result success: %d\n", recovered_result.value());
 
     // Example: Using chain to process intermediary state
     auto final_result = intermediary_result
@@ -70,7 +70,7 @@ int main() {
                                     return Result<int, ErrorCode, int>(intermediary_value + 10); // Promote to success
                                 return Result<int, ErrorCode, int>::failed(ErrorCode::InvalidIntermediary);
                             });
-    if (final_result.is_success()) DBG("Final result success: %d\n", final_result.value());
+    if (final_result.is_success()) SPN_DBG("Final result success: %d\n", final_result.value());
 
     return 0;
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,59 +19,45 @@ build_cache_dir = .pio/build_cache
 monitor_speed = 115200
 build_flags =
     -std=gnu++17
-;    -std=gnu++2a
-;    -std=gnu++2b
+;    -DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF
+;    -DSERIAL_RX_BUFFER_SIZE=256 ; can be used to set UART's RX buffer size (all targets, default: 256)
+;    -DSERIAL_TX_BUFFER_SIZE=256 ; can be used to set UART's TX buffer size (all targets, default: 256)
 build_src_flags =
     -Wall -Wextra -Werror
     -Wshadow
     -Wdouble-promotion
-;    -Wconversion ; for unknown reasons build_src_flags doesnt stick to src dir and trips built of external packages
-    -Wno-format
+    -fno-common
+    -Wformat=2
+    -Wformat-truncation
+    -Wno-format-nonliteral ; needed for strftime with dynamic templates
     -Wno-comment
     -Wno-unused-parameter
     -Wno-unused-function
     -Wno-unused-variable
-;    -Weffc++ ; fun for later
-    -u_printf_float
-    -u_scanf_float
-;    -DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF
-;    -DSERIAL_RX_BUFFER_SIZE=256 ; can be used to set UART's RX buffer size (all targets, default: 256)
-;    -DSERIAL_TX_BUFFER_SIZE=256 ; can be used to set UART's TX buffer size (all targets, default: 256)
 build_unflags =
     -std=c++11
     -std=gnu++11
     -std=c++14
     -std=gnu++14
-;    -std=c++17
-;    -std=gnu++17
-;    -std=gnu++2a
-;    -std=gnu++2b
 debug_build_flags =
     -D DEBUG_SPINE
     -Og
     -g3
-;    -u_printf_float
-;    -u_scanf_float
-;    -DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF
+    -fstack-usage
+    -Wstack-usage=511
+    -Wno-error=stack-usage= ; give warnings for stack usage above 512
 check_tool = cppcheck, clangtidy
 check_flags =
     cppcheck:  --enable=warning,performance,portability
     clangtidy: -extra-arg=-std=c++17 -fix --config-file=.clang-tidy
 
-[arduino]
+[deploy]
 build_flags =
     ${env.build_flags}
-;    -DPIO_FRAMEWORK_ARDUINO_NANOLIB_FLOAT_PRINTF
-lib_deps =
-    ${env.lib_deps}
-
-[embedded]
-build_flags =
-    ${env.build_flags}
-    -D EMBEDDED
+    -Os
 
 [env:esp32]
-extends = embedded, arduino
+extends = deploy
 platform = espressif32
 ; the following custom library is necessary to use the Arduino 3.0 core which supports C++2A
 ; see https://github.com/platformio/platform-espressif32/issues/1225
@@ -80,7 +66,6 @@ board = esp32dev
 framework = arduino
 
 [env:esp32-debug]
-extends = embedded, arduino
 platform = espressif32
 ; the following custom library is necessary to use the Arduino 3.0 core which supports C++2A
 ; see https://github.com/platformio/platform-espressif32/issues/1225
@@ -88,11 +73,9 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 build_type = debug
-debug_build_flags =
-    ${env.debug_build_flags}
 
 [env:sam3x8e]
-extends = embedded, arduino
+extends = deploy
 platform = atmelsam
 board = due
 framework = arduino
@@ -104,13 +87,10 @@ build_src_flags =
     -Wno-shadow
 
 [env:sam3x8e-debug]
-extends = embedded, arduino
 platform = atmelsam
 board = due
 framework = arduino
 build_type = debug
-debug_build_flags =
-    ${env.debug_build_flags}
 build_src_flags =
     ${env.build_src_flags}
     -Wno-expansion-to-defined
@@ -119,14 +99,13 @@ build_src_flags =
     -Wno-shadow
 
 [env:nucleo_f429zi]
-extends = embedded, arduino
+extends = deploy
 platform = ststm32
 board = nucleo_f429zi
 framework = arduino
 upload_protocol = stlink
 
 [env:nucleo_f429zi-debug]
-extends = embedded, arduino
 platform = ststm32
 build_type = debug
 board = nucleo_f429zi
@@ -135,19 +114,17 @@ upload_protocol = stlink
 debug_tool = stlink
 
 [env:nucleo_f429zi-zephyr]
-extends = embedded
+extends = deploy
 platform = ststm32
 board = nucleo_f429zi
 framework = zephyr
 upload_protocol = stlink
 build_flags =
     ${env.build_flags}
-    -Wformat
-    -Wno-error=format-security # needed until format issues are sorted
     -DZEPHYR
 
 [env:nucleo_f411ce]
-extends = embedded, arduino
+extends = deploy
 platform = ststm32
 board = genericSTM32F411RE
 framework = arduino
@@ -155,12 +132,8 @@ upload_protocol = stlink
 debug_tool = stlink
 
 [env:nucleo_f411ce-debug]
-extends = embedded, arduino
 platform = ststm32
 build_type = debug
-build_flags =
-    ${env.build_flags}
-    -D DEBUG_SPINE
 board = genericSTM32F411RE
 framework = arduino
 upload_protocol = stlink
@@ -175,7 +148,6 @@ build_flags =
 debug_build_flags =
     ${env.debug_build_flags}
     -pthread
-build_type = debug
 debug_init_break = tbreak setup
 
 [unittest]
@@ -189,15 +161,10 @@ debug_build_flags =
     -D UNITTEST
     -D_GLIBCXX_DEBUG
     -D_GLIBCXX_ASSERTIONS
-    -ggdb3
-    -Og
     -fno-omit-frame-pointer
     -fno-optimize-sibling-calls
     -fsanitize=address
-    -fstack-protector
-    -fstack-usage
-lib_compat_mode = off
-test_ignore = test_embedded
+    -fstack-protector-all
 test_build_src = yes
 
 [env:unittest]

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = esp32, sam3x8e, nucleo_f429zi, nucleo_f411ce, native
+default_envs = esp32, sam3x8e, nucleo_f429zi, nucleo_f429zi-zephyr, nucleo_f411ce, native
 include_dir = src
 src_dir = src
 build_cache_dir = .pio/build_cache
@@ -133,6 +133,18 @@ board = nucleo_f429zi
 framework = arduino
 upload_protocol = stlink
 debug_tool = stlink
+
+[env:nucleo_f429zi-zephyr]
+extends = embedded
+platform = ststm32
+board = nucleo_f429zi
+framework = zephyr
+upload_protocol = stlink
+build_flags =
+    ${env.build_flags}
+    -Wformat
+    -Wno-error=format-security # needed until format issues are sorted
+    -DZEPHYR
 
 [env:nucleo_f411ce]
 extends = embedded, arduino

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,6 @@
 #include "spine/io/stream/transaction.hpp"
 #include "spine/platform/gpio.hpp"
 #include "spine/platform/hal.hpp"
-#include "spine/platform/platform.hpp"
 #include "spine/platform/protocols/uart.hpp"
 #include "spine/structure/array.hpp"
 #include "spine/structure/linebuffer.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,13 +41,13 @@
 void setup() {
     HAL::initialize(HAL::Config{.baudrate = 115200});
     HAL::delay_ms(500); // give time for monitor to connect after flashing
-    LOG("Wake up");
+    SPN_LOG("Wake up");
 
-    LOG("End of setup. Entering main program.");
+    SPN_LOG("End of setup. Entering main program.");
 }
 
 void loop() {
-    DBG("loop");
+    SPN_DBG("loop");
     HAL::delay_ms(1000);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@
 #include "spine/structure/vector.hpp"
 
 void setup() {
-    HAL::initialize(HAL::Config{.baudrate = 115200});
+    HAL::initialize(HAL::Config{}); // defaults to a baudrate of 115200 if HAL provides UART
     HAL::delay_ms(500); // give time for monitor to connect after flashing
     SPN_LOG("Wake up");
 

--- a/src/spine/controller/implementations/pid/pid_controller.hpp
+++ b/src/spine/controller/implementations/pid/pid_controller.hpp
@@ -101,8 +101,8 @@ public:
 
     void set_tunings(double Kp, double Ki, double Kd,
                      const Proportionality proportionality = Proportionality::ON_MEASUREMENT) {
-        assert(Kp >= 0 && Ki >= 0 && Kd >= 0);
-        assert(_sampling_time > time_ms{});
+        spn_assert(Kp >= 0 && Ki >= 0 && Kd >= 0);
+        spn_assert(_sampling_time > time_ms{});
 
         _proportionality = proportionality;
 

--- a/src/spine/controller/pid.hpp
+++ b/src/spine/controller/pid.hpp
@@ -44,7 +44,7 @@ public:
         : _cfg(cfg),
           _pid_backend(PIDController(&_input, &_output, &_setpoint, _cfg.tunings.Kp, _cfg.tunings.Ki, _cfg.tunings.Kd,
                                      PIDController::Proportionality::ON_MEASUREMENT, _cfg.direction)) {
-        assert(time_ms(_cfg.sample_interval).raw<>() > 0);
+        spn_assert(time_ms(_cfg.sample_interval).raw<>() > 0);
     }
     PID(const Config& cfg) : PID(Config(cfg)) {}
 
@@ -165,8 +165,8 @@ public:
             // Set the output - tunePid() will return values within the range configured
             // by setOutputRange(). Don't change the value or the tuning results will be
             // incorrect.
-            assert(control_value >= _cfg.output_lower_limit);
-            assert(control_value <= _cfg.output_upper_limit);
+            spn_assert(control_value >= _cfg.output_lower_limit);
+            spn_assert(control_value <= _cfg.output_upper_limit);
             process_setter(control_value);
 
             // This loop must run at the same speed as the PID control loop being tuned
@@ -184,7 +184,7 @@ public:
 
     /// Get the controller response
     double response() const {
-        assert(!std::isnan(_output));
+        spn_assert(!std::isnan(_output));
         return _output;
     }
 

--- a/src/spine/controller/sr_latch.hpp
+++ b/src/spine/controller/sr_latch.hpp
@@ -48,10 +48,10 @@ public:
         }
 
         if (value > _cfg.high) {
-            DBG("SRLatch: triggered by high value of %f (lim: %f)", value, _cfg.high);
+            SPN_DBG("SRLatch: triggered by high value of %f (lim: %f)", value, _cfg.high);
             set(State::ON);
         } else if (value < _cfg.low) {
-            DBG("SRLatch: triggered by low value of %f (lim: %f)", value, _cfg.low);
+            SPN_DBG("SRLatch: triggered by low value of %f (lim: %f)", value, _cfg.low);
             set(State::OFF);
         }
     }

--- a/src/spine/controller/sr_latch.hpp
+++ b/src/spine/controller/sr_latch.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "spine/core/debugging.hpp"
+#include "spine/core/types.hpp"
 #include "spine/structure/time/timers.hpp"
 #include "spine/structure/units/si.hpp"
 
@@ -23,25 +24,25 @@ public:
         time_ms maximal_off_time = time_ms{};
     };
 
-    using State = LogicalState;
+    using State = core::LogicalState;
 
     SRLatch(const Config&& cfg) : _cfg(std::move(cfg)), _last_turned(Timer(HAL::millis() - _cfg.minimal_off_time)) {}
 
     void initialize(){}; // boilerplate
 
     void new_reading(double value) {
-        if (_value == LogicalState::ON && _last_turned.time_since_last(Timer::NoReset) < _cfg.minimal_on_time) return;
-        if (_value == LogicalState::OFF && _last_turned.time_since_last(Timer::NoReset) < _cfg.minimal_off_time) return;
+        if (_value == State::ON && _last_turned.time_since_last(Timer::NoReset) < _cfg.minimal_on_time) return;
+        if (_value == State::OFF && _last_turned.time_since_last(Timer::NoReset) < _cfg.minimal_off_time) return;
 
         // If turned on longer than `maximal_on_time`, turn off
-        if (_cfg.maximal_on_time != time_ms{} && _value == LogicalState::ON
+        if (_cfg.maximal_on_time != time_ms{} && _value == State::ON
             && _last_turned.time_since_last(Timer::NoReset) > _cfg.maximal_on_time) {
             set(State::OFF);
             return;
         }
 
         // If turned off longer than `maximal_off_time`, turn on
-        if (_cfg.maximal_off_time != time_ms{} && _value == LogicalState::OFF
+        if (_cfg.maximal_off_time != time_ms{} && _value == State::OFF
             && _last_turned.time_since_last(Timer::NoReset) > _cfg.maximal_off_time) {
             set(State::ON);
             return;

--- a/src/spine/core/debugging.hpp
+++ b/src/spine/core/debugging.hpp
@@ -2,24 +2,16 @@
 
 #include "spine/core/exception.hpp"
 
-#include <cstdio>
-
-#if defined(DEBUG_SPINE)
-
-#    include "spine/core/logging.hpp"
-
+#ifdef spn_assert
+#    error "spn_assert is already defined"
 #endif
 
-#ifdef assert
-#    undef assert
+#ifdef spn_expect
+#    error "spn_expect is already defined"
 #endif
 
-#ifdef expect
-#    undef expect
-#endif
-
-#ifdef DBG
-#    error "DBG is already defined"
+#ifdef SPN_DBG
+#    error "SPN_DBG is already defined"
 #endif
 
 #if defined(DEBUG_SPINE)
@@ -27,7 +19,7 @@
 #    include "spine/core/logging.hpp"
 
 /// Macro to run assertions which, if failing, will log the failed assertion and throw a spn::exception
-#    define assert(__SPINEDEBUG_condition)                                                                             \
+#    define spn_assert(__SPINEDEBUG_condition)                                                                         \
         {                                                                                                              \
             if (!(__SPINEDEBUG_condition)) {                                                                           \
                 ERR("Assertion failed: '%s'", #__SPINEDEBUG_condition);                                                \
@@ -36,23 +28,28 @@
         }
 
 /// Macro to run expectations which, if failing, will log the failed expectation
-#    define expect(__SPINEDEBUG_condition)                                                                             \
+#    define spn_expect(__SPINEDEBUG_condition)                                                                         \
         {                                                                                                              \
             if (!(__SPINEDEBUG_condition)) {                                                                           \
                 ERR("Expectation failed: '%s'", #__SPINEDEBUG_condition);                                              \
             }                                                                                                          \
         }
 
-/// Macro to print debugging statements, output is prefixed with '!'
-#    define DBG(...) LOG_IMPL(spn::logging::LogLevel::DEBUG, __VA_ARGS__)
+/// Macro to print debugging statements. Only is compiled in when SPINE_DEBUG is defined.
+#    define SPN_DBG(...) SPN_LOG_IMPL(spn::logging::LogLevel::DEBUG, __VA_ARGS__)
 #else
-#    define assert(condition)                                                                                          \
+#    define spn_assert(condition)                                                                                      \
         do {                                                                                                           \
         } while (0);
-#    define expect(condition)                                                                                          \
+#    define spn_expect(condition)                                                                                      \
         do {                                                                                                           \
         } while (0);
-#    define DBG(...)                                                                                                   \
+#    define SPN_DBG(...)                                                                                               \
         do {                                                                                                           \
         } while (0);
+#endif
+
+// Alias for SPN_DBG if it was not previously defined.
+#ifndef DBG
+#    define DBG(...) SPN_DBG(__VA_ARGS__)
 #endif

--- a/src/spine/core/debugging.hpp
+++ b/src/spine/core/debugging.hpp
@@ -22,7 +22,7 @@
 #    define spn_assert(__SPINEDEBUG_condition)                                                                         \
         {                                                                                                              \
             if (!(__SPINEDEBUG_condition)) {                                                                           \
-                ERR("Assertion failed: '%s'", #__SPINEDEBUG_condition);                                                \
+                SPN_ERR("Assertion failed: '%s'", #__SPINEDEBUG_condition);                                            \
                 spn::throw_exception(::spn::assertion_exception(#__SPINEDEBUG_condition));                             \
             }                                                                                                          \
         }
@@ -31,7 +31,7 @@
 #    define spn_expect(__SPINEDEBUG_condition)                                                                         \
         {                                                                                                              \
             if (!(__SPINEDEBUG_condition)) {                                                                           \
-                ERR("Expectation failed: '%s'", #__SPINEDEBUG_condition);                                              \
+                SPN_ERR("Expectation failed: '%s'", #__SPINEDEBUG_condition);                                          \
             }                                                                                                          \
         }
 

--- a/src/spine/core/exception.cpp
+++ b/src/spine/core/exception.cpp
@@ -13,7 +13,7 @@ std::unique_ptr<ExceptionHandler> _g_handler = nullptr;
 }
 
 void set_machine_exception_handler(std::unique_ptr<ExceptionHandler> handler) {
-    assert(_g_handler == nullptr);
+    spn_assert(_g_handler == nullptr);
     _g_handler.swap(handler);
 }
 

--- a/src/spine/core/exception.cpp
+++ b/src/spine/core/exception.cpp
@@ -21,11 +21,11 @@ ExceptionHandler* machine_exception_handler() { return _g_handler.get(); }
 
 void Exception::throw_error() const {
     if (const auto eh = machine_exception_handler(); eh != nullptr) {
-        ERR("%s was thrown: %s", error_type(), _error_msg);
+        SPN_ERR("%s was thrown: %s", error_type(), _error_msg);
         eh->handle_exception(*this);
     }
 
-    ERR("%s was thrown: %s, halting without handling exception", error_type(), _error_msg);
+    SPN_ERR("%s was thrown: %s, halting without handling exception", error_type(), _error_msg);
     HAL::halt("Exception was thrown.");
 }
 } // namespace spn::core

--- a/src/spine/core/logging.cpp
+++ b/src/spine/core/logging.cpp
@@ -2,6 +2,8 @@
 
 #include "spine/platform/hal.hpp"
 
+#include <cinttypes>
+
 namespace spn::logging {
 
 namespace {
@@ -29,7 +31,7 @@ namespace detail {
 
 const char* get_current_time() {
     static char time_buffer[32];
-    snprintf(time_buffer, sizeof(time_buffer), "%08u", static_cast<uint32_t>(HAL::millis().raw()));
+    snprintf(time_buffer, sizeof(time_buffer), "%08" PRIu32, static_cast<uint32_t>(HAL::millis().raw()));
     return time_buffer;
 }
 

--- a/src/spine/core/logging.hpp
+++ b/src/spine/core/logging.hpp
@@ -21,38 +21,64 @@ bool is_loggable(LogLevel level);
 
 namespace detail {
 void print(LogLevel level, const char* filename, int line_number, const char* function_name, const char* fmt, ...);
-
-#ifdef LOG_IMPL
-#    error "LOG_IMPL is already defined"
-#endif
-
-#define LOG_IMPL(level, ...)                                                                                           \
-    {                                                                                                                  \
-        if (spn::logging::is_loggable(level)) {                                                                        \
-            spn::logging::detail::print(level, __FILE__, __LINE__, __func__, __VA_ARGS__);                             \
-        }                                                                                                              \
-    }
 } // namespace detail
+
+#ifndef SPN_LOG_IMPL
+/// A user overloadable logging macro that takes a log level (see above) and a printf-style statement
+#    define SPN_LOG_IMPL(level, ...)                                                                                   \
+        {                                                                                                              \
+            if (spn::logging::is_loggable(level)) {                                                                    \
+                spn::logging::detail::print(level, __FILE__, __LINE__, __func__, __VA_ARGS__);                         \
+            }                                                                                                          \
+        }
+#endif
 
 } // namespace spn::logging
 
-#ifdef LOG
-#    error "LOG is already defined"
+/*
+ * LOG: an event that is logged to keep track of the machines normal operation.
+ */
+
+#ifdef SPN_LOG
+#    error "SPN_LOG is already defined"
 #endif
 
 /// Logging macro for informational messages
-#define LOG(...) LOG_IMPL(spn::logging::LogLevel::INFO, __VA_ARGS__)
+#define SPN_LOG(...) SPN_LOG_IMPL(spn::logging::LogLevel::INFO, __VA_ARGS__)
 
-#ifdef WARN
-#    error "WARN is already defined"
+// Alias for SPN_LOG if it was not previously defined.
+#ifndef LOG
+#    define LOG(...) SPN_LOG(__VA_ARGS__)
+#endif
+
+/*
+ * WARN: a recoverable problem that can occur under normal operation but is logged to keep track of.
+ */
+
+#ifdef SPN_WARN
+#    error "SPN_WARN is already defined"
 #endif
 
 /// Logging macro for warning messages
-#define WARN(...) LOG_IMPL(spn::logging::LogLevel::WARN, __VA_ARGS__)
+#define SPN_WARN(...) SPN_LOG_IMPL(spn::logging::LogLevel::WARN, __VA_ARGS__)
 
-#ifdef ERR
-#    error "ERR is already defined"
+// Alias for SPN_WARN if it was not previously defined.
+#ifndef WARN
+#    define WARN(...) SPN_WARN(__VA_ARGS__)
+#endif
+
+/*
+ * ERROR: a recoverable or unrecoverable problem that should not occur under normal operation.
+ */
+
+#ifdef SPN_ERR
+#    error "SPN_ERR is already defined"
 #endif
 
 /// Logging macro for error messages
-#define ERR(...) LOG_IMPL(spn::logging::LogLevel::ERR, __VA_ARGS__)
+#define SPN_ERR(...) SPN_LOG_IMPL(spn::logging::LogLevel::ERR, __VA_ARGS__)
+
+// Alias for SPN_ERR if it was not previously defined.
+#ifndef ERR
+#    define ERR(...) SPN_ERR(__VA_ARGS__)
+#endif

--- a/src/spine/core/logging.hpp
+++ b/src/spine/core/logging.hpp
@@ -3,7 +3,7 @@
 #include "spine/core/exception.hpp"
 
 #ifndef SPINE_DEBUG_BUFFER_SIZE
-#    define SPINE_DEBUG_BUFFER_SIZE 512
+#    define SPINE_DEBUG_BUFFER_SIZE 256
 #endif
 
 namespace spn::logging {

--- a/src/spine/core/logging.hpp
+++ b/src/spine/core/logging.hpp
@@ -23,15 +23,13 @@ namespace detail {
 void print(LogLevel level, const char* filename, int line_number, const char* function_name, const char* fmt, ...);
 } // namespace detail
 
-#ifndef SPN_LOG_IMPL
 /// A user overloadable logging macro that takes a log level (see above) and a printf-style statement
-#    define SPN_LOG_IMPL(level, ...)                                                                                   \
-        {                                                                                                              \
-            if (spn::logging::is_loggable(level)) {                                                                    \
-                spn::logging::detail::print(level, __FILE__, __LINE__, __func__, __VA_ARGS__);                         \
-            }                                                                                                          \
-        }
-#endif
+#define SPN_LOG_IMPL(level, ...)                                                                                       \
+    {                                                                                                                  \
+        if (spn::logging::is_loggable(level)) {                                                                        \
+            spn::logging::detail::print(level, __FILE__, __LINE__, __func__, __VA_ARGS__);                             \
+        }                                                                                                              \
+    }
 
 } // namespace spn::logging
 

--- a/src/spine/core/types.hpp
+++ b/src/spine/core/types.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace spn::core {
+
+enum LogicalState { OFF, ON, UNDEFINED };
+enum class TriggerType { RISING_EDGE, FALLING_EDGE, RISING_AND_FALLING_EDGE, UNDEFINED };
+
+} // namespace spn::core

--- a/src/spine/core/utils/time_repr.hpp
+++ b/src/spine/core/utils/time_repr.hpp
@@ -4,6 +4,7 @@
 
 #include <array>
 // #include <charconv>
+#include <cinttypes>
 #include <cstring>
 #include <iterator>
 #include <numeric>
@@ -55,7 +56,7 @@ inline std::string repr(const TimeType& t) {
                                             : "unknown";
 
     /// todo: this is a workaround, see issue with charconv: https://github.com/s-t-a-n/Spine/issues/21
-    auto size = std::snprintf(buffer.data(), buffer.size(), "%i%s", raw, unit);
+    auto size = std::snprintf(buffer.data(), buffer.size(), "%" PRId64 "%s", static_cast<int64_t>(raw), unit);
     if (size < 0 || static_cast<size_t>(size) >= buffer.size()) {
         return "Error";
     }

--- a/src/spine/eventsystem/eventsystem.hpp
+++ b/src/spine/eventsystem/eventsystem.hpp
@@ -40,27 +40,27 @@ public:
         explicit Data(uint32_t value) : _value(value) {}
 
         double value() const {
-            assert(_value);
+            spn_assert(_value);
             if (!_value) return {};
-            assert(std::holds_alternative<double>(*_value));
+            spn_assert(std::holds_alternative<double>(*_value));
             return std::get<double>(*_value);
         }
         uint32_t unsigned_value() const {
-            assert(_value);
+            spn_assert(_value);
             if (!_value) return {};
-            assert(std::holds_alternative<uint32_t>(*_value));
+            spn_assert(std::holds_alternative<uint32_t>(*_value));
             return std::get<uint32_t>(*_value);
         }
         time_ms ms() const {
-            assert(_value);
+            spn_assert(_value);
             if (!_value) return {};
-            assert(std::holds_alternative<time_ms>(*_value));
+            spn_assert(std::holds_alternative<time_ms>(*_value));
             return std::get<time_ms>(*_value);
         }
         time_s s() const {
-            assert(_value);
+            spn_assert(_value);
             if (!_value) return {};
-            assert(std::holds_alternative<time_s>(*_value));
+            spn_assert(std::holds_alternative<time_s>(*_value));
             return std::get<time_s>(*_value);
         }
 
@@ -89,17 +89,17 @@ class EventHandler {
 public:
     EventHandler(EventSystem* evsys) : _evsys(evsys) {}
 
-    virtual void handle_event(const Event& event) { assert(!"Virtual base function called"); };
+    virtual void handle_event(const Event& event) { spn_assert(!"Virtual base function called"); };
     virtual ~EventHandler() = default;
     void attach_event_system(EventSystem* evsys) {
-        assert(_evsys == nullptr);
-        assert(evsys != nullptr);
+        spn_assert(_evsys == nullptr);
+        spn_assert(evsys != nullptr);
         _evsys = evsys;
     }
 
 protected:
     EventSystem* evsys() {
-        assert(_evsys);
+        spn_assert(_evsys);
         return _evsys;
     };
 
@@ -143,7 +143,7 @@ public:
             auto ev = _store.depopulate();
             ev.reset();
         }
-        assert(_store.size() == 0);
+        spn_assert(_store.size() == 0);
     }
 
 public:
@@ -152,9 +152,9 @@ public:
     template<typename T>
     void attach(T id, EventHandler* handler) {
         auto idx = static_cast<Event::Id>(id);
-        assert(handler != nullptr);
-        assert(idx < _map.size());
-        assert(_map[idx]->size() < _cfg.handler_cap);
+        spn_assert(handler != nullptr);
+        spn_assert(idx < _map.size());
+        spn_assert(_map[idx]->size() < _cfg.handler_cap);
         _map[idx]->push_back(handler);
     };
 
@@ -162,16 +162,16 @@ public:
 
     /// Directly trigger a provided event
     void trigger(const std::shared_ptr<Event>& event) {
-        assert(event);
+        spn_assert(event);
         trigger(*event.get());
     }
 
     /// Directly trigger a provided event
     void trigger(const Event& event) {
         const auto id = event.id();
-        assert(id < _map.size());
-        assert(_map[id] != nullptr);
-        assert(!_map[id]->empty());
+        spn_assert(id < _map.size());
+        spn_assert(_map[id] != nullptr);
+        spn_assert(!_map[id]->empty());
         for (auto handler : *_map[id]) {
             handler->handle_event(event);
         }
@@ -187,7 +187,7 @@ public:
     /// Returns an event for the given id, time_from_now and data
     std::shared_ptr<Event> event(IdType id, const time_ms& time_from_now, const Event::Data& data = {}) {
         auto event = _store.acquire();
-        assert(event); // catch gracefully here for use in nested calls
+        spn_assert(event); // catch gracefully here for use in nested calls
         if (!event) return nullptr;
 
         event->_id = static_cast<Event::Id>(id);
@@ -210,7 +210,7 @@ public:
         while (_pipeline.contains_expired_futures()) {
             // we have futures ready to be processed
             auto future = _pipeline.expire();
-            assert(future != nullptr);
+            spn_assert(future != nullptr);
             auto event = *reinterpret_cast<Event*>(future.get());
             trigger(event);
         }

--- a/src/spine/eventsystem/pipeline.hpp
+++ b/src/spine/eventsystem/pipeline.hpp
@@ -29,7 +29,7 @@ public:
     /// pipeline)
     void reschedule(time_ms time_from_now = time_ms{0}) {
         _time_from_now = time_from_now != time_ms(0) ? time_from_now : _time_from_now;
-        assert(_time_from_now > time_ms{});
+        spn_assert(_time_from_now > time_ms{});
         _timer = time::AlarmTimer(_time_from_now);
     };
 
@@ -59,7 +59,7 @@ public:
 
     /// Push a new future in the pipeline (inserting it in chronological order)
     void push(std::shared_ptr<Future>&& future) {
-        assert(_pipe.size() < _pipe.max_size());
+        spn_assert(_pipe.size() < _pipe.max_size());
         future->reschedule();
 
         size_t i = 0;
@@ -67,7 +67,7 @@ public:
             if (future->time_until_future().raw<int32_t>() < other_future->time_until_future().raw<int32_t>()) {
                 [[maybe_unused]] auto last_size = _pipe.size();
                 _pipe.insert(i, std::move(future));
-                assert(last_size + 1 == _pipe.size());
+                spn_assert(last_size + 1 == _pipe.size());
                 return;
             }
             i++;
@@ -77,12 +77,12 @@ public:
 
     /// Takes the first next future to fire from the pipeline
     [[nodiscard]] std::shared_ptr<Future> expire() {
-        assert(!_pipe.empty());
+        spn_assert(!_pipe.empty());
         if (_pipe.empty()) return nullptr;
 
         const auto future = _pipe.pop_front();
-        assert(future); // gracefully catch
-        assert(future->expired()); // gracefully catch
+        spn_assert(future); // gracefully catch
+        spn_assert(future->expired()); // gracefully catch
         if (!future->expired()) return nullptr;
         return future;
     }
@@ -133,8 +133,8 @@ public:
         // Second pass to build the string
         pipeline_repr(&result, false);
 
-        assert(result.size() <= total_length); // no reallocation
-        assert(result.capacity() == total_length); // no reallocation
+        spn_assert(result.size() <= total_length); // no reallocation
+        spn_assert(result.capacity() == total_length); // no reallocation
         return result;
     }
 

--- a/src/spine/filter/filterstack.hpp
+++ b/src/spine/filter/filterstack.hpp
@@ -17,13 +17,13 @@ public:
 
     /// Attach a filter to the provided slot's index
     void attach_filter(std::unique_ptr<Filter<ValueType>> filter) {
-        assert(_filters.size() < _filters.max_size());
+        spn_assert(_filters.size() < _filters.max_size());
         _filters.emplace_back(std::move(filter));
     }
 
     /// Detach a filter for a provided slot's index
     std::unique_ptr<Filter<ValueType>> detach_filter(uint8_t index) {
-        assert(index < _filters.size());
+        spn_assert(index < _filters.size());
         return _filters.remove(index);
     }
 
@@ -31,7 +31,7 @@ public:
     ValueType value(const double new_sample) {
         ValueType new_value = new_sample;
         for (auto& sf : _filters) {
-            assert(sf.get() != nullptr);
+            spn_assert(sf.get() != nullptr);
             new_value = sf->value(new_value);
         }
         return new_value;

--- a/src/spine/filter/implementations/bandpass.hpp
+++ b/src/spine/filter/implementations/bandpass.hpp
@@ -50,7 +50,7 @@ public:
 
     BandPass(const Config&& cfg) : _cfg(std::move(cfg)) {
         static_assert(std::is_floating_point_v<ValueType>, "ValueType must be a floating point type");
-        assert(_cfg.mantissa >= 1.0 && _cfg.mantissa < 10.0); // sanity
+        spn_assert(_cfg.mantissa >= 1.0 && _cfg.mantissa < 10.0); // sanity
         BandPass::update_limits();
     }
 

--- a/src/spine/filter/implementations/bandpass.hpp
+++ b/src/spine/filter/implementations/bandpass.hpp
@@ -65,9 +65,9 @@ public:
             return;
         }
 
-        DBG("--------------------------------------------------------------------------");
-        DBG("Bandpass rejected value of %f, limits: low: %f, high: %f", sample, _lower, _upper);
-        DBG("--------------------------------------------------------------------------");
+        SPN_DBG("--------------------------------------------------------------------------");
+        SPN_DBG("Bandpass rejected value of %f, limits: low: %f, high: %f", sample, _lower, _upper);
+        SPN_DBG("--------------------------------------------------------------------------");
 
         if (++_rejections > _cfg.rejection_limit) {
             if (_cfg.throw_on_rejection_limit) {

--- a/src/spine/filter/implementations/invert.hpp
+++ b/src/spine/filter/implementations/invert.hpp
@@ -32,7 +32,7 @@ public:
 
     /// Take a new sample, returns filtered value
     ValueType value(const ValueType sample) override {
-        assert(sample >= _cfg.input_lower_limit && sample <= _cfg.input_upper_limit);
+        spn_assert(sample >= _cfg.input_lower_limit && sample <= _cfg.input_upper_limit);
         return _value = _cfg.input_upper_limit - (sample - _cfg.input_lower_limit);
     }
 

--- a/src/spine/filter/implementations/mapped_range.hpp
+++ b/src/spine/filter/implementations/mapped_range.hpp
@@ -45,10 +45,10 @@ public:
     /// Take a new sample, returns filtered value (throws when value is out of range)
     ValueType value(ValueType sample) override {
         if (sample < _cfg.input_lower_limit || sample > _cfg.input_upper_limit) {
-            DBG("--------------------------------------------------------------------------");
-            DBG("MappedRange rejected value of %f, limits: lower: %f, upper: %f", sample, _cfg.input_lower_limit,
-                _cfg.input_upper_limit);
-            DBG("--------------------------------------------------------------------------");
+            SPN_DBG("--------------------------------------------------------------------------");
+            SPN_DBG("MappedRange rejected value of %f, limits: lower: %f, upper: %f", sample, _cfg.input_lower_limit,
+                    _cfg.input_upper_limit);
+            SPN_DBG("--------------------------------------------------------------------------");
             if (_cfg.throw_for_value_out_of_range) {
                 spn::throw_exception(spn::runtime_exception("MappedRange: Value out of range"));
             }

--- a/src/spine/io/sensor.hpp
+++ b/src/spine/io/sensor.hpp
@@ -33,7 +33,7 @@ public:
     }
 
     double value() const {
-        assert(_value != DefaultSensorValue);
+        spn_assert(_value != DefaultSensorValue);
         return _value;
     }
 

--- a/src/spine/io/stream/implementations/mock.hpp
+++ b/src/spine/io/stream/implementations/mock.hpp
@@ -55,8 +55,8 @@ public:
 
 protected:
     void swap_streams() {
-        assert(_active_in != nullptr);
-        assert(_active_out != nullptr);
+        spn_assert(_active_in != nullptr);
+        spn_assert(_active_out != nullptr);
         std::swap(_active_in, _active_out);
     }
 

--- a/src/spine/io/stream/stream.hpp
+++ b/src/spine/io/stream/stream.hpp
@@ -17,20 +17,20 @@ public:
 
     size_t read(char* const buffer, size_t length) { return read((uint8_t*)buffer, length); };
     virtual size_t read(uint8_t* buffer, size_t length) {
-        assert(!"Virtual base function called");
+        spn_assert(!"Virtual base function called");
         return -1;
     };
     virtual bool read(uint8_t& value) {
-        assert(!"Virtual base function called");
+        spn_assert(!"Virtual base function called");
         return false;
     };
 
     virtual size_t available() const {
-        assert(!"Virtual base function called");
+        spn_assert(!"Virtual base function called");
         return -1;
     };
     virtual size_t available_for_write() const {
-        assert(!"Virtual base function called");
+        spn_assert(!"Virtual base function called");
         return -1;
     };
 
@@ -39,15 +39,15 @@ public:
     bool write(const char value) { return write(static_cast<uint8_t>(value)); }
 
     virtual size_t write(const uint8_t* const buffer, size_t length) {
-        assert(!"Virtual base function called");
+        spn_assert(!"Virtual base function called");
         return -1;
     };
     virtual bool write(const uint8_t value) {
-        assert(!"Virtual base function called");
+        spn_assert(!"Virtual base function called");
         return false;
     };
 
-    virtual void flush() { assert(!"Virtual base function called"); }
+    virtual void flush() { spn_assert(!"Virtual base function called"); }
 };
 
 } // namespace spn::io

--- a/src/spine/io/stream/transaction.cpp
+++ b/src/spine/io/stream/transaction.cpp
@@ -4,28 +4,28 @@
 
 namespace spn::io {
 Transaction::Transaction(BufferedStream* stream, std::optional<size_t> discovered_length) : _stream(stream) {
-    assert(_stream);
+    spn_assert(_stream);
     const auto length = discovered_length ? *discovered_length : _stream->length_of_next_line();
-    assert(length > 0); // A transaction shouldn't be started without a line ready to be read
+    spn_assert(length > 0); // A transaction shouldn't be started without a line ready to be read
     const auto next_line_view = _stream->get_next_line_view(length);
-    assert(next_line_view); // catch this because it could get nasty if left unhandled
+    spn_assert(next_line_view); // catch this because it could get nasty if left unhandled
     if (next_line_view) _incoming_line = *next_line_view;
 }
 const std::string_view& Transaction::incoming() const {
-    assert(!is_finalized());
+    spn_assert(!is_finalized());
     return _incoming_line;
 }
 size_t Transaction::outgoing(char value) {
-    assert(!is_finalized());
-    assert(outgoing_space_left() > 0);
+    spn_assert(!is_finalized());
+    spn_assert(outgoing_space_left() > 0);
     if (outgoing_space_left() == 0) return 0;
     const auto bytes_written = _stream->buffered_write(value);
     _outgoing_queued_bytes += bytes_written;
     return bytes_written;
 }
 size_t Transaction::outgoing(const char* buffer, size_t length) {
-    assert(!is_finalized());
-    assert(outgoing_space_left() > length); // todo: instead make it optional to flush out bytes in between
+    spn_assert(!is_finalized());
+    spn_assert(outgoing_space_left() > length); // todo: instead make it optional to flush out bytes in between
     length = std::min(outgoing_space_left(), length);
     size_t bytes_written = _stream->buffered_write(buffer, length);
     _outgoing_queued_bytes += bytes_written;
@@ -35,17 +35,17 @@ size_t Transaction::outgoing(const char* buffer, size_t length) {
 size_t Transaction::outgoing_space_left() const { return _stream->output_buffer_space_left(); }
 size_t Transaction::outgoing_space_used() const { return _outgoing_queued_bytes; }
 void Transaction::commit() {
-    assert(!is_finalized());
+    spn_assert(!is_finalized());
     _outgoing_queued_bytes = 0; // effectively commit outgoing bytes;
     finalize();
 }
 void Transaction::abort() {
-    assert(!is_finalized());
+    spn_assert(!is_finalized());
     undo();
     finalize();
 }
 void Transaction::finalize() {
-    assert(!is_finalized());
+    spn_assert(!is_finalized());
     if (!is_finalized()) {
         _stream->drop_next_line(); // remove the line from the incoming buffer
         _incoming_line = {};

--- a/src/spine/platform/gpio.cpp
+++ b/src/spine/platform/gpio.cpp
@@ -8,7 +8,7 @@ namespace spn::platform::detail {
 
 void fade_to(void (*set_value)(void*, double), void* imp, double value, double setpoint, double increment,
              time_ms increment_interval) {
-    assert(setpoint >= 0.0 && setpoint <= 1.0);
+    spn_assert(setpoint >= 0.0 && setpoint <= 1.0);
 
     const double decimals_of_diff = 1.0 / increment;
     double diff = std::round(std::fabs(value - setpoint) * decimals_of_diff) / decimals_of_diff;

--- a/src/spine/platform/gpio.hpp
+++ b/src/spine/platform/gpio.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "spine/core/meta/enum.hpp"
 #include "spine/core/types.hpp"
 #include "spine/structure/units/si.hpp"
 
@@ -9,26 +8,30 @@ namespace spn::platform {
 template<typename GPIOImp>
 class DigitalOutput {
 public:
+    using LogicalState = core::LogicalState;
+
     void initialize(bool active = false) {
         static_cast<GPIOImp*>(this)->initialize_impl();
         set_state(active);
     }
     void set_state(core::LogicalState state) {
         static_cast<GPIOImp*>(this)->set_state_impl(state);
-        _active = core::meta::ENUM_IDX(state);
+        _active = state;
     }
     void set_state(bool active) { set_state(static_cast<core::LogicalState>(active)); }
     void flip() { set_state(!state()); }
-    [[nodiscard]] bool state() const { return _active; }
+    LogicalState state() const { return _active; }
 
 private:
-    bool _active = false;
+    LogicalState _active = LogicalState::OFF;
 };
 
 template<typename GPIOImp>
 struct DigitalInput {
+    using LogicalState = core::LogicalState;
+
     void initialize() { static_cast<GPIOImp>(this)->initialize(); }
-    [[nodiscard]] bool state() const { return static_cast<GPIOImp>(this)->state(); }
+    LogicalState state() const { return static_cast<GPIOImp>(this)->state(); }
 };
 
 namespace detail {

--- a/src/spine/platform/gpio.hpp
+++ b/src/spine/platform/gpio.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
+#include "spine/core/meta/enum.hpp"
+#include "spine/core/types.hpp"
 #include "spine/structure/units/si.hpp"
-
-enum LogicalState { OFF, ON, UNDEFINED };
-enum class TriggerType { RISING_EDGE, FALLING_EDGE, RISING_AND_FALLING_EDGE, UNDEFINED };
 
 namespace spn::platform {
 
@@ -14,11 +13,11 @@ public:
         static_cast<GPIOImp*>(this)->initialize_impl();
         set_state(active);
     }
-    void set_state(LogicalState state) {
+    void set_state(core::LogicalState state) {
         static_cast<GPIOImp*>(this)->set_state_impl(state);
-        _active = state;
+        _active = core::meta::ENUM_IDX(state);
     }
-    void set_state(bool active) { set_state(static_cast<LogicalState>(active)); }
+    void set_state(bool active) { set_state(static_cast<core::LogicalState>(active)); }
     void flip() { set_state(!state()); }
     [[nodiscard]] bool state() const { return _active; }
 
@@ -76,7 +75,7 @@ struct AnalogueInput {
 
 template<typename GPIOImp>
 struct Interrupt {
-    using TriggerType = ::TriggerType;
+    using TriggerType = core::TriggerType;
 
     /// Intializes the interrupt (doesn't attach it)
     void initialize() { static_cast<GPIOImp>(this)->initialize(); }

--- a/src/spine/platform/hal.hpp
+++ b/src/spine/platform/hal.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "spine/platform/platform.hpp"
-
 #if defined(ARDUINO)
+
 #    include "spine/platform/implementations/arduino.hpp"
 using HAL = spn::platform::Platform<spn::platform::Arduino, //
                                     spn::platform::ArduinoConfig, //
                                     spn::platform::ArduinoGPIO, //
-                                    spn::platform::ArduinoUART>;
+                                    spn::platform::ArduinoAnalogue, spn::platform::ArduinoUART>;
 using ArduinoConfig = spn::platform::ArduinoConfig;
 
 #elif defined(NATIVE)
@@ -15,14 +14,34 @@ using ArduinoConfig = spn::platform::ArduinoConfig;
 using HAL = spn::platform::Platform<spn::platform::Mock, //
                                     spn::platform::MockConfig, //
                                     spn::platform::MockGPIO, //
+                                    spn::platform::MockAnalogue, //
                                     spn::platform::MockUART>;
 using MockConfig = spn::platform::MockConfig;
 
+#elif defined(ZEPHYR)
+#    include "spine/platform/implementations/zephyr.hpp"
+using HAL = spn::platform::Platform<spn::platform::Zephyr, //
+                                    spn::platform::ZephyrConfig>;
+using ZephyrConfig = spn::platform::ZephyrConfig;
+#else
+
+#    error "Platform not supported"
+
 #endif
 
+#if defined(SPINE_PLATFORM_CAP_GPIO)
 using DigitalOutput = HAL::DigitalOutput;
 using DigitalInput = HAL::DigitalInput;
-using AnalogueOutput = HAL::AnalogueOutput;
-using AnalogueInput = HAL::AnalogueInput;
+#endif
 
+#if defined(SPINE_PLATFORM_CAP_ADC)
+using AnalogueInput = HAL::AnalogueInput;
+#endif
+
+#if defined(SPINE_PLATFORM_CAP_PWM)
+using AnalogueOutput = HAL::AnalogueOutput;
+#endif
+
+#if defined(SPINE_PLATFORM_CAP_GPIO_INTERRUPTS)
 using Interrupt = HAL::Interrupt;
+#endif

--- a/src/spine/platform/implementations/arduino.hpp
+++ b/src/spine/platform/implementations/arduino.hpp
@@ -48,8 +48,8 @@ public:
 protected:
     void initialize_impl() { pinMode(_cfg.pin, OUTPUT); }
 
-    void set_state_impl(LogicalState state) {
-        if (state == LogicalState::ON) digitalWrite(_cfg.pin, !_cfg.active_on_low);
+    void set_state_impl(core::LogicalState state) {
+        if (state == core::LogicalState::ON) digitalWrite(_cfg.pin, !_cfg.active_on_low);
         else
             digitalWrite(_cfg.pin, _cfg.active_on_low);
     }
@@ -283,7 +283,7 @@ struct ArduinoAnalogue {
 };
 
 struct ArduinoConfig {
-    uint32_t baudrate;
+    uint32_t baudrate = 115200;
 };
 
 struct Arduino : public Platform<Arduino, ArduinoConfig, ArduinoGPIO, ArduinoAnalogue, ArduinoUART> {

--- a/src/spine/platform/implementations/arduino.hpp
+++ b/src/spine/platform/implementations/arduino.hpp
@@ -1,4 +1,14 @@
 #pragma once
+
+#define SPINE_PLATFORM_CAP_UART
+#define SPINE_PLATFORM_CAP_GPIO
+#define SPINE_PLATFORM_CAP_GPIO_INTERRUPTS
+#define SPINE_PLATFORM_CAP_ADC
+#define SPINE_PLATFORM_CAP_PWM
+#define SPINE_PLATFORM_CAP_PRINT
+#define SPINE_PLATFORM_CAP_PRINTF
+#define SPINE_PLATFORM_CAP_MEMORY_METRICS
+
 #include "spine/core/debugging.hpp"
 #include "spine/core/logging.hpp"
 #include "spine/platform/gpio.hpp"
@@ -264,17 +274,19 @@ private:
 struct ArduinoGPIO {
     using DigitalOutput = ArduinoDigitalOutput;
     using DigitalInput = ArduinoDigitalInput;
+    using Interrupt = ArduinoInterrupt;
+};
+
+struct ArduinoAnalogue {
     using AnalogueOutput = ArduinoAnalogueOutput;
     using AnalogueInput = ArduinoAnalogueInput;
-
-    using Interrupt = ArduinoInterrupt;
 };
 
 struct ArduinoConfig {
     uint32_t baudrate;
 };
 
-struct Arduino : public Platform<Arduino, ArduinoConfig, ArduinoGPIO, ArduinoUART> {
+struct Arduino : public Platform<Arduino, ArduinoConfig, ArduinoGPIO, ArduinoAnalogue, ArduinoUART> {
     static void initialize(Config&& cfg) {
 #if defined(NATIVE)
         ARDUINO_MOCK_ALL();

--- a/src/spine/platform/implementations/arduino.hpp
+++ b/src/spine/platform/implementations/arduino.hpp
@@ -95,9 +95,7 @@ public:
     ~ArduinoAnalogueOutput() {}
 
     void initialize() {
-#if defined(EMBEDDED)
         analogWriteResolution(_cfg.resolution);
-#endif
         set_value(0.0);
     }
 

--- a/src/spine/platform/implementations/arduino.hpp
+++ b/src/spine/platform/implementations/arduino.hpp
@@ -103,7 +103,7 @@ public:
 
     // value between 0 and 1 where 1 is the logical state ON
     void set_value(double value) {
-        assert(value >= 0.0 && value <= 1.0);
+        spn_assert(value >= 0.0 && value <= 1.0);
         if (_cfg.active_on_low) value = 1.0 - value;
 
         analogWrite(_cfg.pin, int(value * std::pow(2, _cfg.resolution)));
@@ -189,10 +189,10 @@ public:
     void attach_interrupt(void (*callback)() = nullptr, TriggerType trigger = TriggerType::UNDEFINED) {
         int mode_bits;
         auto callback_actual = callback ? callback : _callback;
-        //        assert(callback_actual);
+        //        spn_assert(callback_actual);
 
         auto mode_actual = trigger != TriggerType::UNDEFINED ? trigger : _mode;
-        //        assert(mode_actual != Mode::NOP);
+        //        spn_assert(mode_actual != Mode::NOP);
 
         switch (mode_actual) {
         case TriggerType::RISING_AND_FALLING_EDGE: mode_bits = 1; break;
@@ -207,7 +207,7 @@ public:
 #if defined(__AVR_ATmega8__) || defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__)
         ::attachInterrupt(_cfg.pin, callback_actual, mode_bits);
 #else
-        assert(digitalPinToInterrupt(_cfg.pin) != NOT_AN_INTERRUPT);
+        spn_assert(digitalPinToInterrupt(_cfg.pin) != NOT_AN_INTERRUPT);
         ::attachInterrupt(digitalPinToInterrupt(_cfg.pin), callback_actual, mode_bits);
 #endif
     }
@@ -243,11 +243,11 @@ public:
     void initialize() override { _stream_ref->setTimeout(_cfg.timeout.raw<unsigned long>()); }
 
     size_t available() const override {
-        assert(_stream_ref);
+        spn_assert(_stream_ref);
         return static_cast<size_t>(_stream_ref->available());
     };
     size_t available_for_write() const override {
-        assert(_stream_ref);
+        spn_assert(_stream_ref);
         return static_cast<size_t>(_stream_ref->availableForWrite());
     }
 

--- a/src/spine/platform/implementations/arduino.hpp
+++ b/src/spine/platform/implementations/arduino.hpp
@@ -306,7 +306,7 @@ struct Arduino : public Platform<Arduino, ArduinoConfig, ArduinoGPIO, ArduinoAna
     };
 
     static void halt(const char* msg = NULL) {
-        LOG("Halting with reason: %s", msg ? msg : "[not specified]");
+        SPN_LOG("Halting with reason: %s", msg ? msg : "[not specified]");
         delay(time_s(2));
         noInterrupts();
         while (true) {

--- a/src/spine/platform/implementations/mock.hpp
+++ b/src/spine/platform/implementations/mock.hpp
@@ -44,7 +44,7 @@ public:
 
 protected:
     void initialize_impl() {}
-    void set_state_impl(LogicalState state) {}
+    void set_state_impl(core::LogicalState state) {}
 
     friend DigitalOutput;
 

--- a/src/spine/platform/implementations/mock.hpp
+++ b/src/spine/platform/implementations/mock.hpp
@@ -2,6 +2,15 @@
 
 #ifdef NATIVE
 
+#    define SPINE_PLATFORM_CAP_UART
+#    define SPINE_PLATFORM_CAP_GPIO
+#    define SPINE_PLATFORM_CAP_GPIO_INTERRUPTS
+#    define SPINE_PLATFORM_CAP_ADC
+#    define SPINE_PLATFORM_CAP_PWM
+#    define SPINE_PLATFORM_CAP_PRINT
+#    define SPINE_PLATFORM_CAP_PRINTF
+#    define SPINE_PLATFORM_CAP_MEMORY_METRICS
+
 #    include "spine/core/debugging.hpp"
 #    include "spine/io/stream/stream.hpp"
 #    include "spine/platform/gpio.hpp"
@@ -162,10 +171,12 @@ private:
 struct MockGPIO {
     using DigitalOutput = MockDigitalOutput;
     using DigitalInput = MockDigitalInput;
+    using Interrupt = MockInterrupt;
+};
+
+struct MockAnalogue {
     using AnalogueOutput = MockAnalogueOutput;
     using AnalogueInput = MockAnalogueInput;
-
-    using Interrupt = MockInterrupt;
 };
 
 struct MockConfig {
@@ -179,7 +190,7 @@ static inline struct MockState {
     time_t micros = 0;
 } g_mock_state;
 
-struct Mock : Platform<Mock, MockConfig, MockGPIO, MockUART> {
+struct Mock : Platform<Mock, MockConfig, MockGPIO, MockAnalogue, MockUART> {
     static void initialize(Config&& cfg){};
 
     static void halt(const char* msg = nullptr) {}

--- a/src/spine/platform/implementations/mock.hpp
+++ b/src/spine/platform/implementations/mock.hpp
@@ -87,7 +87,7 @@ public:
 
     // value between 0 and 1 where 1 is the logical state ON
     void set_value(double value) {
-        assert(value >= 0.0 && value <= 1.0);
+        spn_assert(value >= 0.0 && value <= 1.0);
         if (_cfg.active_on_low) value = 1.0 - value;
     }
 

--- a/src/spine/platform/implementations/zephyr.cpp
+++ b/src/spine/platform/implementations/zephyr.cpp
@@ -1,0 +1,43 @@
+#ifdef ZEPHYR
+
+#    include "spine/platform/implementations/zephyr.hpp"
+
+#    include <zephyr/logging/log.h>
+
+#    ifdef DEBUG_SPINE
+LOG_MODULE_REGISTER(spine, LOG_LEVEL_DBG);
+#    else
+LOG_MODULE_REGISTER(spine, LOG_LEVEL_INF);
+#    endif
+
+namespace spn::platform {
+
+void zephyr_log(const spn::logging::LogLevel level, const char* msg) {
+    switch (level) {
+    case spn::logging::LogLevel::ERR: LOG_ERR("%s", msg); break;
+    case spn::logging::LogLevel::WARN: LOG_WRN("%s", msg); break;
+    case spn::logging::LogLevel::INFO: LOG_INF("%s", msg); break;
+    case spn::logging::LogLevel::DEBUG: LOG_DBG("%s", msg); break;
+    default: break;
+    }
+}
+
+#    ifdef CONFIG_LOG_RUNTIME_FILTERING
+#        include <zephyr/logging/log_ctrl.h>
+
+void zephyr_set_log_level(spn::logging::LogLevel level) {
+    LOG_MODULE_DECLARE(spine, LOG_LEVEL_INF);
+
+    switch (level) {
+    case spn::logging::LogLevel::OFF: log_filter_set(log_backend_get_by_name("spine"), 0, 0, LOG_LEVEL_NONE);
+    case spn::logging::LogLevel::ERR: log_filter_set(log_backend_get_by_name("spine"), 0, 0, LOG_LEVEL_ERR); break;
+    case spn::logging::LogLevel::WARN: log_filter_set(log_backend_get_by_name("spine"), 0, 0, LOG_LEVEL_WRN); break;
+    case spn::logging::LogLevel::INFO: log_filter_set(log_backend_get_by_name("spine"), 0, 0, LOG_LEVEL_INF); break;
+    case spn::logging::LogLevel::DEBUG: log_filter_set(log_backend_get_by_name("spine"), 0, 0, LOG_LEVEL_DBG); break;
+    default: break;
+    }
+}
+#    endif
+} // namespace spn::platform
+
+#endif

--- a/src/spine/platform/implementations/zephyr.hpp
+++ b/src/spine/platform/implementations/zephyr.hpp
@@ -19,7 +19,7 @@ struct Zephyr : Platform<Zephyr, ZephyrConfig> {
 
     static void halt(const char* msg = nullptr) {
         if (msg) {
-            LOG_ERR("System halt: %s", msg);
+            SPN_LOG_ERR("System halt: %s", msg);
         }
         k_panic(); // Halt the system in Zephyr
     }

--- a/src/spine/platform/implementations/zephyr.hpp
+++ b/src/spine/platform/implementations/zephyr.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#ifdef ZEPHYR
+
+#    include "spine/core/debugging.hpp"
+#    include "spine/io/stream/stream.hpp"
+#    include "spine/platform/platform.hpp"
+
+#    include <logging/log.h>
+#    include <sys/time.h>
+#    include <zephyr.h>
+
+namespace spn::platform {
+
+struct ZephyrConfig {};
+
+struct Zephyr : Platform<Zephyr, ZephyrConfig> {
+    static void initialize(Config&& cfg){};
+
+    static void halt(const char* msg = nullptr) {
+        if (msg) {
+            LOG_ERR("System halt: %s", msg);
+        }
+        k_panic(); // Halt the system in Zephyr
+    }
+
+    static time_ms millis() { return time_ms(k_uptime_get()); }
+    static time_us micros() { return time_us(k_ticks_to_us_near32(k_uptime_ticks())); }
+    static void delay_us(time_us us) {
+        if (us.raw() >= 1000) {
+            k_msleep(us / 1000);
+        } else {
+            k_busy_wait(us.raw()); // Busy wait for shorter delays
+        }
+    }
+    static void delay_ms(time_ms ms) { k_msleep(ms.raw()); }
+};
+
+} // namespace spn::platform
+
+#endif

--- a/src/spine/structure/array.hpp
+++ b/src/spine/structure/array.hpp
@@ -138,7 +138,7 @@ Array<T>::Array(Size max_size, T init_value) : Array(max_size) {
 
 template<typename T>
 Array<T>::Array(const std::initializer_list<T>& init_values) : Array(init_values.size()) {
-    assert(max_size() == init_values.size());
+    spn_assert(max_size() == init_values.size());
     auto i = 0;
     for (auto& obj : init_values) {
         m_store[i++] = obj;

--- a/src/spine/structure/pool.hpp
+++ b/src/spine/structure/pool.hpp
@@ -18,7 +18,7 @@ public:
     ~Pool() {
         for (size_t i = 0; i < _pointers.size(); ++i)
             depopulate().reset();
-        assert(_pointers.empty());
+        spn_assert(_pointers.empty());
     }
     Pool(const Pool& other) : _pointers(other._pointers), _lookup_index(other._lookup_index) {}
     Pool& operator=(const Pool& other) {
@@ -36,25 +36,25 @@ public:
 
     /// Populate the pool with a raw pointer object.
     void populate(T* obj) {
-        assert(!_pointers.full());
+        spn_assert(!_pointers.full());
         _pointers.emplace_back(std::shared_ptr<T>(obj));
     }
 
     /// Populate the pool with an r-value object.
     void populate(T&& obj) {
-        assert(!_pointers.full());
+        spn_assert(!_pointers.full());
         _pointers.emplace_back(std::make_shared<T>(std::move(obj)));
     }
 
     /// Populate the pool with a shared_ptr object.
     void populate(std::shared_ptr<T> obj) {
-        assert(!_pointers.full());
+        spn_assert(!_pointers.full());
         _pointers.emplace_back(std::move(obj));
     }
 
     /// Depopulate a single element from the pool.
     [[nodiscard]] Pointer&& depopulate() {
-        assert(!_pointers.empty());
+        spn_assert(!_pointers.empty());
         return _pointers.pop_front();
     }
 
@@ -63,7 +63,7 @@ public:
 
     /// Returns a pointer-object from the pool if available, or a nullptr;
     Pointer acquire() {
-        assert(is_fully_populated());
+        spn_assert(is_fully_populated());
         // Assume that it is most common for memory to be accessed and released in order; look in the back
         const auto skipped = _lookup_index;
         for (; _lookup_index < _pointers.size(); ++_lookup_index) {

--- a/src/spine/structure/result.hpp
+++ b/src/spine/structure/result.hpp
@@ -48,38 +48,38 @@ public:
     operator bool() const { return _type == Type::OK; }
 
     const E& error_value() const {
-        assert(is_failed());
-        assert(_v && std::holds_alternative<WrappedE>(*_v));
+        spn_assert(is_failed());
+        spn_assert(_v && std::holds_alternative<WrappedE>(*_v));
         return std::get<WrappedE>(*_v);
     }
 
     const I& intermediary_value() const {
-        assert(is_intermediary());
-        assert(_v && std::holds_alternative<WrappedI>(*_v));
+        spn_assert(is_intermediary());
+        spn_assert(_v && std::holds_alternative<WrappedI>(*_v));
         return std::get<WrappedI>(*_v);
     }
 
     const T& value() const {
-        assert(is_success());
-        assert(_v && std::holds_alternative<WrappedT>(*_v));
+        spn_assert(is_success());
+        spn_assert(_v && std::holds_alternative<WrappedT>(*_v));
         return std::get<WrappedT>(*_v);
     }
 
     E unwrap_error_value() {
-        assert(is_failed());
-        assert(_v && std::holds_alternative<WrappedE>(*_v));
+        spn_assert(is_failed());
+        spn_assert(_v && std::holds_alternative<WrappedE>(*_v));
         return std::move(std::get<WrappedE>(*_v));
     }
 
     I unwrap_intermediary_value() {
-        assert(is_intermediary());
-        assert(_v && std::holds_alternative<WrappedI>(*_v));
+        spn_assert(is_intermediary());
+        spn_assert(_v && std::holds_alternative<WrappedI>(*_v));
         return std::move(std::get<WrappedI>(*_v));
     }
 
     T unwrap() {
-        assert(is_success() || is_intermediary());
-        assert(_v && std::holds_alternative<WrappedT>(*_v));
+        spn_assert(is_success() || is_intermediary());
+        spn_assert(_v && std::holds_alternative<WrappedT>(*_v));
         return std::move(std::get<WrappedT>(*_v));
     }
 
@@ -168,7 +168,7 @@ public:
 
 protected:
     I& intermediary_value_mut() {
-        assert(is_intermediary());
+        spn_assert(is_intermediary());
         return std::get<WrappedI>(*_v);
     }
 

--- a/src/spine/structure/ringbuffer.hpp
+++ b/src/spine/structure/ringbuffer.hpp
@@ -8,7 +8,7 @@ namespace spn::structure {
 template<typename T>
 class RingBuffer {
 public:
-    RingBuffer(size_t capacity, T init_value = {}) : m_buffer(capacity, init_value) { assert(capacity > 0); }
+    RingBuffer(size_t capacity, T init_value = {}) : m_buffer(capacity, init_value) { spn_assert(capacity > 0); }
 
     /// Push an element into ringbuffer. Returns true if succesful.
     /// If provided `rollover` is true (default: false), elements can be overwritten if there is not enough space.

--- a/src/spine/structure/static_string.hpp
+++ b/src/spine/structure/static_string.hpp
@@ -21,7 +21,7 @@ public:
 
     /// Set the size of the string (this is not the same as the capacity!).
     void set_size(size_t size) {
-        assert(size <= capacity()); // do not allow reallocation
+        spn_assert(size <= capacity()); // do not allow reallocation
         _buffer.resize(std::min<>(size, capacity()));
     }
 

--- a/src/spine/structure/time/datetime.cpp
+++ b/src/spine/structure/time/datetime.cpp
@@ -86,7 +86,7 @@ static uint8_t bcd2bin(uint8_t val) { return static_cast<uint8_t>(val - 6 * (val
  */
 DateTime::DateTime(time_t unix_timestamp)
     : _unix_timestamp{unix_timestamp}, _y2k_timestamp{static_cast<time_t>(unix_timestamp - UNIX_OFFSET)} {
-    assert(unix_timestamp - UNIX_OFFSET <= LONG_MAX);
+    spn_assert(unix_timestamp - UNIX_OFFSET <= LONG_MAX);
     gmtime_r(&_unix_timestamp, &_tm);
 }
 

--- a/src/spine/structure/time/schedule.hpp
+++ b/src/spine/structure/time/schedule.hpp
@@ -30,10 +30,10 @@ public:
     Schedule(const std::initializer_list<Block>& blocks) : _blocks(blocks) {
         time_s total_time = {};
         for (auto& b : _blocks) {
-            assert(time_s(b.duration) > time_s(0));
+            spn_assert(time_s(b.duration) > time_s(0));
             total_time += b.duration;
         }
-        assert(total_time <= time_h(24));
+        spn_assert(total_time <= time_h(24));
     }
 
     /// Returns the value in the block of `t` or 0

--- a/src/spine/structure/time/timers.hpp
+++ b/src/spine/structure/time/timers.hpp
@@ -34,7 +34,7 @@ public:
     /// for `future`=time_ms(200) and `absolute`=false, have this expire at 200 ms from now
     /// for `absolute`=true, future is absolute length of time offset on `millis()`
     AlarmTimer(time_ms future, bool absolute = false) : _future(absolute ? future : HAL::millis() + future) {
-        assert(!absolute || future > HAL::millis());
+        spn_assert(!absolute || future > HAL::millis());
     };
 
     /// Returns true if the timer has expired

--- a/src/spine/structure/units/unit.hpp
+++ b/src/spine/structure/units/unit.hpp
@@ -10,6 +10,8 @@ namespace spn::core {
 template<typename U, typename M, typename T>
 class Unit {
 public:
+    using ValueType = T;
+
     Unit() = default;
     explicit Unit(const T length) : _value(length) {}
 

--- a/src/spine/structure/vector.hpp
+++ b/src/spine/structure/vector.hpp
@@ -74,7 +74,7 @@ public:
 private:
     /// Rearrange memory such that after rearranging, the elements start at `idx`
     void rearrange(Size idx) {
-        assert(idx + size() < Array<T>::max_size());
+        spn_assert(idx + size() < Array<T>::max_size());
 
         // todo: convert this brutal C-stuff into nice and fluffy CPP-stuff
         memmove((char*)&this->m_store[idx], (char*)&this->m_store[m_head], size() * sizeof(T));
@@ -84,7 +84,7 @@ private:
         // todo, optimize: only wipe elements that overlapped
         // todo: convert this brutal C-stuff into nice and fluffy CPP-stuff
         memset((char*)&this->m_store[0], '\0', new_head * sizeof(T)); // wipe all elements before `new_head`
-        assert(size() - new_tail < this->max_size());
+        spn_assert(size() - new_tail < this->max_size());
         memset((char*)&this->m_store[new_tail], '\0',
                (this->max_size() - new_tail) * sizeof(T)); // wipe all elements after `new_tail`
 
@@ -120,20 +120,20 @@ Vector<T>::Vector(T (&store)[CAP], ArrayBase::Size size) : Array<T>(store), m_ta
 
 template<typename T>
 T& Vector<T>::operator[](ArrayBase::Size index) {
-    assert(m_head + index < m_tail);
+    spn_assert(m_head + index < m_tail);
     return Array<T>::operator[](m_head + index);
 }
 
 template<typename T>
 const T& Vector<T>::operator[](ArrayBase::Size index) const {
-    assert(m_head + index < m_tail);
+    spn_assert(m_head + index < m_tail);
     return Array<T>::operator[](m_head + index);
 }
 
 template<typename T>
 void Vector<T>::push_back(const T& item) {
     if (m_tail >= this->max_size() && m_head > 0) rearrange(0);
-    assert(m_tail < this->max_size());
+    spn_assert(m_tail < this->max_size());
 
     if (m_tail < this->max_size()) this->m_store[m_tail++] = item;
 }
@@ -141,23 +141,23 @@ void Vector<T>::push_back(const T& item) {
 template<typename T>
 void Vector<T>::emplace_back(const T&& item) {
     if (m_tail >= this->max_size() && m_head > 0) rearrange(0);
-    assert(m_tail < this->max_size());
+    spn_assert(m_tail < this->max_size());
 
     if (m_tail < this->max_size()) {
-        assert(sizeof(item) == sizeof(T));
+        spn_assert(sizeof(item) == sizeof(T));
         this->m_store[m_tail++] = std::move(item);
     }
 }
 
 template<typename T>
 T& Vector<T>::peek_back() const {
-    assert(size() > 0);
+    spn_assert(size() > 0);
     return (this->m_store[m_tail - 1]);
 }
 
 template<typename T>
 [[nodiscard]] T&& Vector<T>::pop_back() {
-    assert(size() > 0);
+    spn_assert(size() > 0);
     if (m_tail > 0) {
         m_tail--;
         if (m_tail == m_head) {
@@ -170,7 +170,7 @@ template<typename T>
 
 template<typename T>
 void Vector<T>::push_front(const T& item) {
-    assert(this->size() < this->max_size());
+    spn_assert(this->size() < this->max_size());
     if (m_head > 0) {
         this->m_store[--m_head] = item;
         return;
@@ -203,13 +203,13 @@ void Vector<T>::emplace_front(const T&& item) {
 
 template<typename T>
 T& Vector<T>::peek_front() const {
-    assert(size() > 0);
+    spn_assert(size() > 0);
     return (this->m_store[m_head]);
 }
 
 template<typename T>
 T&& Vector<T>::pop_front() {
-    assert(size() > 0);
+    spn_assert(size() > 0);
     const auto cur_head = m_head++;
     if (m_tail == m_head) {
         m_tail = 0;
@@ -220,7 +220,7 @@ T&& Vector<T>::pop_front() {
 
 template<typename T>
 void Vector<T>::insert(ArrayBase::Size index, const T& item) {
-    assert(this->size() < this->m_max_size);
+    spn_assert(this->size() < this->m_max_size);
 
     if (index == 0) {
         push_front(item);
@@ -231,7 +231,7 @@ void Vector<T>::insert(ArrayBase::Size index, const T& item) {
         return;
     }
     if (m_tail >= this->max_size() && m_head > 0) rearrange(0);
-    assert(m_tail < this->max_size());
+    spn_assert(m_tail < this->max_size());
 
     // todo: convert this brutal C-stuff into nice and fluffy CPP-stuff
     memmove((char*)&this->m_store[m_head + index + 1], (char*)&this->m_store[m_head + index],
@@ -258,7 +258,7 @@ T Vector<T>::remove(ArrayBase::Size index) {
         }
         return removed;
     }
-    assert(!"remove was called with illegal index");
+    spn_assert(!"remove was called with illegal index");
     return {};
 }
 

--- a/test/test_core_schedule/test_core_schedule.cpp
+++ b/test/test_core_schedule/test_core_schedule.cpp
@@ -53,22 +53,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_core_units/test_units.cpp
+++ b/test/test_core_units/test_units.cpp
@@ -79,22 +79,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_io_buffered_stream/test_io_buffered_stream.cpp
+++ b/test/test_io_buffered_stream/test_io_buffered_stream.cpp
@@ -134,25 +134,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
-#if defined(ARDUINO)
-    ARDUINO_MOCK_ALL();
-#endif
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_io_stream/test_io_stream.cpp
+++ b/test/test_io_stream/test_io_stream.cpp
@@ -42,25 +42,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
-#if defined(ARDUINO)
-    ARDUINO_MOCK_ALL();
-#endif
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_structure_array/test_array.cpp
+++ b/test/test_structure_array/test_array.cpp
@@ -166,22 +166,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_structure_linebuffer/test_structure_linebuffer.cpp
+++ b/test/test_structure_linebuffer/test_structure_linebuffer.cpp
@@ -83,25 +83,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
-#if defined(ARDUINO)
-    ARDUINO_MOCK_ALL();
-#endif
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_structure_pool/test_structure_pool.cpp
+++ b/test/test_structure_pool/test_structure_pool.cpp
@@ -65,7 +65,9 @@ void ut_pool_allocation_basics() {
         TEST_ASSERT_EQUAL(false, bool(p.acquire()));
 
         // verify that a slice becomes available when the shared ptr reaches a single reference to self
-        { auto r = results.pop_back(); }
+        {
+            auto r = results.pop_back();
+        }
         TEST_ASSERT_EQUAL(true, bool(p.acquire()));
         TEST_ASSERT_EQUAL(results.size() * 2 + 1, sum_of_sp_usecounts(p));
 
@@ -154,25 +156,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
-#if defined(ARDUINO)
-    ARDUINO_MOCK_ALL();
-#endif
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_structure_result/test_structure_result.cpp
+++ b/test/test_structure_result/test_structure_result.cpp
@@ -333,25 +333,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
-#if defined(ARDUINO)
-    ARDUINO_MOCK_ALL();
-#endif
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_structure_ringbuffer/test_structure_ringbuffer.cpp
+++ b/test/test_structure_ringbuffer/test_structure_ringbuffer.cpp
@@ -186,25 +186,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
-#if defined(ARDUINO)
-    ARDUINO_MOCK_ALL();
-#endif
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_structure_vector/test_vector.cpp
+++ b/test/test_structure_vector/test_vector.cpp
@@ -412,25 +412,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
-#if defined(ARDUINO)
-    ARDUINO_MOCK_ALL();
-#endif
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_structure_xypoint/test_xypoint.cpp
+++ b/test/test_structure_xypoint/test_xypoint.cpp
@@ -92,22 +92,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
     run_all_tests();
     return 0;
 }
+#endif

--- a/test/test_structure_xyzpoint/test_xyzpoint.cpp
+++ b/test/test_structure_xyzpoint/test_xyzpoint.cpp
@@ -93,22 +93,19 @@ int run_all_tests() {
     return UNITY_END();
 }
 
-#if defined(ARDUINO) && defined(EMBEDDED)
+#if defined(ARDUINO)
 #    include <Arduino.h>
 void setup() {
     // NOTE!!! Wait for >2 secs
     // if board doesn't support software reset via Serial.DTR/RTS
     delay(2000);
-
     run_all_tests();
 }
 
 void loop() {}
-#elif defined(ARDUINO)
-#    include <ArduinoFake.h>
-#endif
-
+#else
 int main(int argc, char** argv) {
     run_all_tests();
     return 0;
 }
+#endif

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.13.1)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+
+# Platformio demands a CMake project declaration in this folder
+# Zephyr demands a Zephyr specialized CMake declaration in this folder
+# Both can be found below.
+
+file(GLOB_RECURSE SPINE_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/../src/*.hpp
+)
+
+# Check if Zephyr is already included (e.g., when using West)
+if (EXISTS "${CMAKE_SOURCE_DIR}/../.pio")
+    message(STATUS "Spine building modality: platformio")
+    project(Spine)
+    target_sources(app PRIVATE ${SPINE_SOURCES})
+    target_include_directories(app PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+    target_compile_definitions(app PRIVATE ZEPHYR)
+else ()
+    message(STATUS "Spine building modality: zephyr")
+    zephyr_library_named(spine)
+    zephyr_library_sources(${SPINE_SOURCES})
+    target_include_directories(spine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+    target_compile_definitions(spine PRIVATE ZEPHYR)
+endif ()
+
+
+
+
+
+

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,2 @@
+build:
+  cmake: zephyr

--- a/zephyr/prj.conf
+++ b/zephyr/prj.conf
@@ -1,0 +1,5 @@
+CONFIG_CPP=y
+CONFIG_REQUIRES_FULL_LIBCPP=y # needs full lib for STL stuff like optional/smart pointers
+CONFIG_STD_CPP17=y # using the C++17 ISO standard
+CONFIG_STDOUT_CONSOLE=y
+


### PR DESCRIPTION
## What and why <!-- a short descripton of what this PR is trying to solve-->


- To use Spine on Zephyr, we have to disable some stuff that we dont want to use/implement on Zephyr as it seems rather pointless. This commit allows capacities to be defined in the platform implementation files so that the user of platform only ends up with with they need.
- Adds Zephyr implementation of platform, providing kernel delay, time of startup and a halt function. This is so that components of the Spine library won't need to be specialized outside of unsupported platforms.


## Checklist

- [x] Compartmentalize platform so new platforms dont need to support every aspect
- [x] Make generic statements like `assert` and `LOG` prefixed with `spn`
- [x] Re-enable format check flags as NANO-printf is out of the question anyway.
- [x] Make debug and other logging statements portable (through platform?)
- [x] Test on a Zephyr build

