### PR TITLE
structure/bidirectional_list: Add BidirectionalList

### DIFF
--- a/src/spine/structure/bidirectional_list.hpp
+++ b/src/spine/structure/bidirectional_list.hpp
@@ -1,0 +1,385 @@
+#pragma once
+
+#include <spine/core/debugging.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+namespace spn::structure {
+
+template<typename T>
+/// A link to be inherited from for use with a BidirectionalList
+class BidirectionalLink {
+public:
+    BidirectionalLink() = default;
+    BidirectionalLink(const BidirectionalLink&) = delete;
+    BidirectionalLink& operator=(const BidirectionalLink&) = delete;
+    ~BidirectionalLink() { unlink(); }
+
+    /// Returns total length of nodes on the left of this node until and including the leaf node or `term`
+    [[nodiscard]] constexpr std::size_t depth_to_back(BidirectionalLink* term = nullptr) const {
+        std::size_t distance = 1;
+        for (auto* node = next(); node; node = node->next(), ++distance)
+            if (node == term) break;
+        return distance;
+    }
+
+    /// Returns total length of nodes on the right of this node until and including the leaf node or `term`
+    [[nodiscard]] constexpr std::size_t depth_to_front(BidirectionalLink* term = nullptr) const {
+        std::size_t distance = 1;
+        for (auto* node = prev(); node && node != term; node = node->prev(), ++distance) {
+        }
+        return distance;
+    }
+
+    /// Returns the leaf node all the way on the left
+    T& leaf_front() {
+        auto* node = this;
+        while (node->prev())
+            node = node->prev();
+        return static_cast<T&>(*node);
+    }
+
+    /// Returns the leaf node all the way on the right
+    T& leaf_back() {
+        auto* node = this;
+        while (node->next())
+            node = node->next();
+        return static_cast<T&>(*node);
+    }
+
+    constexpr T* prev() const { return (_prev && !_prev->_is_sentinel) ? static_cast<T*>(_prev) : nullptr; }
+    constexpr T* next() const { return (_next && !_next->_is_sentinel) ? static_cast<T*>(_next) : nullptr; }
+
+    bool has_prev() const { return prev(); }
+    bool has_next() const { return next(); }
+
+    /// Inserts this node before the `anchor` node
+    void insert_before(BidirectionalLink& anchor) {
+        spn_assert(&anchor != this);
+        link_between(anchor._prev, &anchor);
+    }
+
+    /// Inserts this node after the `anchor` node
+    void insert_after(BidirectionalLink& anchor) {
+        spn_assert(&anchor != this);
+        link_between(&anchor, anchor._next);
+    }
+
+    /// Detach this node it's neighbours
+    void unlink() {
+        if (_prev) _prev->_next = _next;
+        if (_next) _next->_prev = _prev;
+        _prev = _next = nullptr;
+    }
+
+    /// Attach `node` to the left of current node
+    void attach_prev(BidirectionalLink* node) noexcept {
+        if (!node || node == this) return;
+        node->link_between(_prev, this);
+    }
+
+    /// Attach `node` to the right of current node
+    void attach_next(BidirectionalLink* node) noexcept {
+        if (!node || node == this) return;
+        node->link_between(this, _next);
+    }
+
+    template<typename>
+    friend class BidirectionalList;
+
+private:
+    void link_between(BidirectionalLink* left, BidirectionalLink* right) noexcept {
+        _prev = left;
+        _next = right;
+        if (left) left->_next = this;
+        if (right) right->_prev = this;
+    }
+
+    BidirectionalLink* _prev{nullptr};
+    BidirectionalLink* _next{nullptr};
+    bool _is_sentinel{false};
+
+    struct SentinelTag {};
+    explicit BidirectionalLink(SentinelTag) : _is_sentinel(true) {}
+};
+
+template<typename T>
+/** A list for bidirectional traversal of nodes that may dynamically unlink.
+ * Note: Since nodes may dynamically unlink, getting the size() of the list is always O(N)
+ * Note: This list is designed for ordering nodes, not for preserving their lifetime.
+ **/
+class BidirectionalList {
+    static_assert(std::is_base_of_v<BidirectionalLink<T>, T>, "T must inherit from BidirectionalLink<T>");
+
+    using Node = BidirectionalLink<T>;
+
+public:
+    class iterator {
+    public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using reference = T&;
+
+        iterator() = default;
+
+        reference operator*() const noexcept { return *static_cast<T*>(_node); }
+        pointer operator->() const noexcept { return static_cast<T*>(_node); }
+
+        iterator& operator++() noexcept {
+            if (_node != _sentinel) _node = _node->_next;
+            return *this;
+        }
+        iterator operator++(int) noexcept {
+            auto tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        iterator& operator--() noexcept {
+            if (_node == _sentinel) {
+                _node = _sentinel->_prev;
+            } else if (_node->_prev != _sentinel) {
+                _node = _node->_prev;
+            }
+            return *this;
+        }
+        iterator operator--(int) noexcept {
+            auto tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        friend bool operator==(const iterator& a, const iterator& b) noexcept { return a._node == b._node; }
+        friend bool operator!=(const iterator& a, const iterator& b) noexcept { return !(a == b); }
+
+        friend bool operator==(const iterator& it, const T* p) noexcept { return it._node == p; }
+        friend bool operator==(const T* p, const iterator& it) noexcept { return p == it._node; }
+        friend bool operator!=(const iterator& it, const T* p) noexcept { return it._node != p; }
+        friend bool operator!=(const T* p, const iterator& it) noexcept { return p != it._node; }
+
+    private:
+        friend class BidirectionalList;
+
+        iterator(Node* n, Node* s) : _node(n), _sentinel(s) {}
+
+        Node* _node{nullptr};
+        Node* _sentinel{nullptr};
+    };
+
+    class reverse_iterator {
+    public:
+        using iterator_category = std::bidirectional_iterator_tag;
+        using value_type = T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using reference = T&;
+
+        reverse_iterator() = default;
+        explicit reverse_iterator(const iterator& it) : _sentinel(it._sentinel) {
+            if (it._node == _sentinel) _node = (_sentinel->_prev == _sentinel) ? nullptr : _sentinel->_prev;
+            else if (it._node->_prev == _sentinel)
+                _node = nullptr;
+            else
+                _node = it._node->_prev;
+        }
+
+        iterator base() const noexcept { return iterator(_node ? _node->_next : _sentinel->_next, _sentinel); }
+
+        reference operator*() const noexcept {
+            spn_assert(_node);
+            return *static_cast<T*>(_node);
+        }
+        pointer operator->() const noexcept {
+            spn_assert(_node);
+            return static_cast<T*>(_node);
+        }
+
+        reverse_iterator& operator++() noexcept {
+            if (_node) _node = (_node->_prev == _sentinel) ? nullptr : _node->_prev;
+            return *this;
+        }
+        reverse_iterator operator++(int) noexcept {
+            auto tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        reverse_iterator& operator--() noexcept {
+            _node = _node ? _node->_next : _sentinel->_prev;
+            return *this;
+        }
+        reverse_iterator operator--(int) noexcept {
+            auto tmp = *this;
+            --(*this);
+            return tmp;
+        }
+
+        friend bool operator==(const reverse_iterator& a, const reverse_iterator& b) noexcept {
+            return a._node == b._node;
+        }
+        friend bool operator!=(const reverse_iterator& a, const reverse_iterator& b) noexcept { return !(a == b); }
+
+    private:
+        friend class BidirectionalList;
+
+        reverse_iterator(Node* n, Node* s) : _node(n), _sentinel(s) {}
+
+        Node* _node{nullptr};
+        Node* _sentinel{nullptr};
+    };
+
+    using const_iterator = iterator;
+    using const_reverse_iterator = reverse_iterator;
+
+    BidirectionalList() noexcept { clear(); }
+
+    template<typename U>
+    explicit BidirectionalList(U& root) noexcept {
+        clear();
+        init_from_chain(&root.leaf_front(), &root.leaf_back());
+    }
+
+    template<typename U, typename V>
+    BidirectionalList(U& head, V& tail) noexcept {
+        clear();
+        init_from_chain(&head, &tail);
+    }
+
+    BidirectionalList(const BidirectionalList&) = delete;
+    BidirectionalList& operator=(const BidirectionalList&) = delete;
+
+    BidirectionalList(BidirectionalList&& other) noexcept { move_from(other); }
+    BidirectionalList& operator=(BidirectionalList&& other) noexcept {
+        if (this != &other) {
+            clear();
+            move_from(other);
+        }
+        return *this;
+    }
+
+    ~BidirectionalList() = default;
+
+    iterator begin() noexcept { return {_sentinel._next, &_sentinel}; }
+    iterator end() noexcept { return {&_sentinel, &_sentinel}; }
+    const_iterator begin() const noexcept { return {_sentinel._next, const_cast<Node*>(&_sentinel)}; }
+    const_iterator end() const noexcept { return {const_cast<Node*>(&_sentinel), const_cast<Node*>(&_sentinel)}; }
+    const_iterator cbegin() const noexcept { return begin(); }
+    const_iterator cend() const noexcept { return end(); }
+
+    reverse_iterator rbegin() noexcept { return {_sentinel._prev, &_sentinel}; }
+    reverse_iterator rend() noexcept { return {nullptr, &_sentinel}; }
+    const_reverse_iterator rbegin() const noexcept { return {_sentinel._prev, const_cast<Node*>(&_sentinel)}; }
+    const_reverse_iterator rend() const noexcept { return {nullptr, const_cast<Node*>(&_sentinel)}; }
+    const_reverse_iterator crbegin() const noexcept { return rbegin(); }
+    const_reverse_iterator crend() const noexcept { return rend(); }
+
+    bool empty() const noexcept { return _sentinel._next == &_sentinel; }
+    size_t size() const noexcept {
+        size_t count = 0;
+        for (auto* p = _sentinel._next; p != &_sentinel; p = p->_next)
+            ++count;
+        return count;
+    }
+
+    T& front() noexcept { return *static_cast<T*>(_sentinel._next); }
+    T& back() noexcept { return *static_cast<T*>(_sentinel._prev); }
+    const T& front() const noexcept { return *static_cast<const T*>(_sentinel._next); }
+    const T& back() const noexcept { return *static_cast<const T*>(_sentinel._prev); }
+
+    void clear() noexcept { _sentinel._next = _sentinel._prev = &_sentinel; }
+
+    void push_front(Node& n) noexcept {
+        ensure_detached(n);
+        insert_after(_sentinel, n);
+    }
+    void push_back(Node& n) noexcept {
+        ensure_detached(n);
+        insert_before(_sentinel, n);
+    }
+
+    void pop_front() noexcept {
+        spn_assert(!empty());
+        erase(*_sentinel._next);
+    }
+    void pop_back() noexcept {
+        spn_assert(!empty());
+        erase(*_sentinel._prev);
+    }
+
+    iterator insert_before(const iterator& pos, Node& n) noexcept {
+        ensure_detached(n);
+        insert_before(*pos._node, n);
+        return {&n, &_sentinel};
+    }
+    iterator insert_before(const reverse_iterator& rpos, Node& n) noexcept {
+        const_iterator fwd = rpos.base();
+        if (fwd == end()) {
+            push_back(n);
+            return iterator(_sentinel._prev, &_sentinel);
+        }
+        --fwd;
+        return insert_after(fwd, n);
+    }
+
+    iterator insert_after(const iterator& pos, Node& n) noexcept {
+        ensure_detached(n);
+        insert_after(*pos._node, n);
+        return {&n, &_sentinel};
+    }
+    iterator insert_after(const reverse_iterator& rpos, Node& n) noexcept {
+        const_iterator fwd = rpos.base();
+        if (fwd == begin()) {
+            push_front(n);
+            return begin();
+        }
+        return insert_before(fwd, n);
+    }
+
+    iterator erase(const iterator& it) noexcept {
+        Node* current = it._node;
+        Node* next = current->_next;
+        current->unlink();
+        return {next, &_sentinel};
+    }
+    iterator erase(Node& n) noexcept { return erase(iterator(&n, &_sentinel)); }
+    iterator erase(Node* n) noexcept { return erase(iterator(n, &_sentinel)); }
+
+private:
+    static void ensure_detached(Node& n) noexcept {
+        if (n._prev || n._next) n.unlink();
+    }
+
+    static void insert_after(Node& anchor, Node& node) noexcept {
+        node._prev = &anchor;
+        node._next = anchor._next;
+        anchor._next->_prev = &node;
+        anchor._next = &node;
+    }
+    static void insert_before(Node& anchor, Node& node) noexcept { insert_after(*anchor._prev, node); }
+
+    void init_from_chain(Node* head, Node* tail) noexcept {
+        _sentinel._next = head;
+        _sentinel._prev = tail;
+        head->_prev = &_sentinel;
+        tail->_next = &_sentinel;
+    }
+
+    void move_from(BidirectionalList& other) noexcept {
+        if (other.empty()) {
+            clear();
+            return;
+        }
+        _sentinel._next = other._sentinel._next;
+        _sentinel._prev = other._sentinel._prev;
+        _sentinel._next->_prev = &_sentinel;
+        _sentinel._prev->_next = &_sentinel;
+        other.clear();
+    }
+
+    Node _sentinel{typename Node::SentinelTag{}};
+};
+
+} // namespace spn::structure

--- a/test/test_structure_bidirectional_list/test_structure_bidirectional_list.cpp
+++ b/test/test_structure_bidirectional_list/test_structure_bidirectional_list.cpp
@@ -1,0 +1,809 @@
+#include <spine/structure/bidirectional_list.hpp>
+#include <unity.h>
+
+#include <climits>
+#include <cstdint>
+#include <cstdlib>
+#include <vector>
+
+using namespace spn::structure;
+
+namespace {
+
+class Node : public BidirectionalLink<Node> {
+public:
+    Node(int value = 0) : _value(value) {}
+
+    int value() const { return _value; }
+
+private:
+    int _value = 0;
+};
+
+// verify bidirectional link pointer integrity
+void ut_bidirectional_link_pointers() {
+    Node node1(1);
+    Node node2(2);
+    Node node3(3);
+
+    // link nodes: node1 <-> node2 <-> node3
+    node1.attach_next(&node2);
+    node2.attach_next(&node3);
+
+    // verify node1 pointers
+    TEST_ASSERT_FALSE(node1.has_prev());
+    TEST_ASSERT_TRUE(node1.has_next());
+    TEST_ASSERT_EQUAL_PTR(nullptr, node1.prev());
+    TEST_ASSERT_EQUAL_PTR(&node2, node1.next());
+
+    // verify node2 pointers
+    TEST_ASSERT_TRUE(node2.has_prev());
+    TEST_ASSERT_TRUE(node2.has_next());
+    TEST_ASSERT_EQUAL_PTR(&node1, node2.prev());
+    TEST_ASSERT_EQUAL_PTR(&node3, node2.next());
+
+    // verify node3 pointers
+    TEST_ASSERT_TRUE(node3.has_prev());
+    TEST_ASSERT_FALSE(node3.has_next());
+    TEST_ASSERT_EQUAL_PTR(&node2, node3.prev());
+    TEST_ASSERT_EQUAL_PTR(nullptr, node3.next());
+}
+
+// verify attach_prev / attach_next maintain relationships
+void ut_bidirectional_link_attach_prev_next() {
+    Node node1(1), node2(2), node3(3), node4(4), node5(5), node0(0);
+
+    // attach node2 to node1 (node1 <-> node2)
+    node1.attach_next(&node2);
+
+    // verify pointers after attaching node2
+    TEST_ASSERT_EQUAL_PTR(&node2, node1.next());
+    TEST_ASSERT_EQUAL_PTR(&node1, node2.prev());
+
+    // attach node3 after node2 (node1 <-> node2 <-> node3)
+    node2.attach_next(&node3);
+
+    // verify pointers
+    TEST_ASSERT_EQUAL_PTR(&node2, node1.next());
+    TEST_ASSERT_EQUAL_PTR(&node3, node2.next());
+    TEST_ASSERT_EQUAL_PTR(&node2, node3.prev());
+    TEST_ASSERT_EQUAL_PTR(nullptr, node1.prev());
+    TEST_ASSERT_EQUAL_PTR(nullptr, node3.next());
+
+    // attach node4 after node3 (node1 <-> node2 <-> node3 <-> node4)
+    node3.attach_next(&node4);
+
+    // verify pointers
+    TEST_ASSERT_EQUAL_PTR(&node4, node3.next());
+    TEST_ASSERT_EQUAL_PTR(&node3, node4.prev());
+    TEST_ASSERT_EQUAL_PTR(nullptr, node4.next());
+
+    // attach node5 after node4 (node1 <-> node2 <-> node3 <-> node4 <-> node5)
+    node4.attach_next(&node5);
+
+    // verify pointers
+    TEST_ASSERT_EQUAL_PTR(&node5, node4.next());
+    TEST_ASSERT_EQUAL_PTR(&node4, node5.prev());
+    TEST_ASSERT_EQUAL_PTR(nullptr, node5.next());
+
+    // attach node0 before node1 (node0 <-> node1 ...)
+    node1.attach_prev(&node0);
+
+    // verify node0 / node1 pointers
+    TEST_ASSERT_EQUAL_PTR(&node0, node1.prev());
+    TEST_ASSERT_EQUAL_PTR(&node1, node0.next());
+    TEST_ASSERT_EQUAL_PTR(nullptr, node0.prev());
+
+    // walk chain forward and verify values
+    Node* current = &node0;
+    std::vector<int> actual;
+    while (current) {
+        actual.push_back(current->value());
+        current = current->next();
+    }
+    const std::vector<int> expected = {0, 1, 2, 3, 4, 5};
+    TEST_ASSERT_EQUAL_INT_ARRAY(expected.data(), actual.data(), expected.size());
+}
+
+// verify unlink on head, middle, and tail
+void ut_bidirectional_link_unlink() {
+    Node node1(1), node2(2), node3(3), node4(4);
+
+    // link nodes: node1 <-> node2 <-> node3 <-> node4
+    node1.attach_next(&node2);
+    node2.attach_next(&node3);
+    node3.attach_next(&node4);
+
+    // unlink head
+    node1.unlink();
+    TEST_ASSERT_NULL(node1.next());
+    TEST_ASSERT_NULL(node1.prev());
+    TEST_ASSERT_EQUAL_PTR(&node3, node2.next());
+    TEST_ASSERT_EQUAL_PTR(&node2, node3.prev());
+
+    // unlink middle (node3)
+    node3.unlink();
+    TEST_ASSERT_NULL(node3.next());
+    TEST_ASSERT_NULL(node3.prev());
+    TEST_ASSERT_EQUAL_PTR(&node4, node2.next());
+    TEST_ASSERT_EQUAL_PTR(&node2, node4.prev());
+
+    // unlink tail
+    node4.unlink();
+    TEST_ASSERT_NULL(node4.next());
+    TEST_ASSERT_NULL(node4.prev());
+    TEST_ASSERT_EQUAL_PTR(nullptr, node2.next());
+}
+
+// verify leaf_back / leaf_front helpers
+void ut_bidirectional_link_leaf_accessors() {
+    Node node1(1), node2(2), node3(3);
+
+    // link nodes: node1 <-> node2 <-> node3
+    node1.attach_next(&node2);
+    node2.attach_next(&node3);
+
+    // verify front leaves
+    TEST_ASSERT_EQUAL_PTR(&node1, &node1.leaf_front());
+    TEST_ASSERT_EQUAL_PTR(&node1, &node2.leaf_front());
+    TEST_ASSERT_EQUAL_PTR(&node1, &node3.leaf_front());
+
+    // verify back leaves
+    TEST_ASSERT_EQUAL_PTR(&node3, &node1.leaf_back());
+    TEST_ASSERT_EQUAL_PTR(&node3, &node2.leaf_back());
+    TEST_ASSERT_EQUAL_PTR(&node3, &node3.leaf_back());
+}
+
+// verify default-constructed list is empty
+void ut_bidirectional_list_initialization() {
+    BidirectionalList<Node> list;
+    TEST_ASSERT_TRUE(list.empty());
+    TEST_ASSERT_EQUAL_size_t(0, list.size());
+}
+
+// verify list constructors
+void ut_bidirectional_list_constructors() {
+    // single-node constructor
+    Node root1(10);
+    BidirectionalList<Node> list1(root1);
+    TEST_ASSERT_FALSE(list1.empty());
+    TEST_ASSERT_EQUAL_size_t(1, list1.size());
+    TEST_ASSERT_EQUAL_INT(10, list1.front().value());
+    TEST_ASSERT_EQUAL_INT(10, list1.back().value());
+
+    // root == leaf
+    BidirectionalList<Node> list2(root1, root1);
+    TEST_ASSERT_FALSE(list2.empty());
+    TEST_ASSERT_EQUAL_size_t(1, list2.size());
+    TEST_ASSERT_EQUAL_INT(10, list2.front().value());
+    TEST_ASSERT_EQUAL_INT(10, list2.back().value());
+
+    // distinct root / leaf
+    Node root2(20), leaf2(30);
+    root2.attach_next(&leaf2);
+    BidirectionalList<Node> list3(root2, leaf2);
+    TEST_ASSERT_FALSE(list3.empty());
+    TEST_ASSERT_EQUAL_size_t(2, list3.size());
+    TEST_ASSERT_EQUAL_INT(20, list3.front().value());
+    TEST_ASSERT_EQUAL_INT(30, list3.back().value());
+
+    // push_back should ignore duplicate link
+    list3.push_back(leaf2);
+    TEST_ASSERT_EQUAL_size_t(2, list3.size());
+    TEST_ASSERT_EQUAL_INT(20, list3.front().value());
+    TEST_ASSERT_EQUAL_INT(30, list3.back().value());
+}
+
+// verify move constructor
+void ut_bidirectional_list_copy_constructor() {
+    BidirectionalList<Node> list1;
+    Node node1(1), node2(2);
+    list1.push_back(node1);
+    list1.push_back(node2);
+
+    BidirectionalList<Node> list2 = std::move(list1);
+    TEST_ASSERT_EQUAL_size_t(2, list2.size());
+    TEST_ASSERT_EQUAL_size_t(0, list1.size());
+
+    auto it = list2.begin();
+    TEST_ASSERT_EQUAL_INT(1, it->value());
+    ++it;
+    TEST_ASSERT_EQUAL_INT(2, it->value());
+}
+
+// verify single element insertion / removal
+void ut_bidirectional_list_single_insertion() {
+    BidirectionalList<Node> list;
+    Node node1(1);
+
+    list.push_back(node1);
+    TEST_ASSERT_FALSE(list.empty());
+    TEST_ASSERT_EQUAL_size_t(1, list.size());
+    TEST_ASSERT_EQUAL_INT(1, list.front().value());
+    TEST_ASSERT_EQUAL_INT(1, list.back().value());
+
+    list.pop_front();
+    TEST_ASSERT_TRUE(list.empty());
+    TEST_ASSERT_EQUAL_size_t(0, list.size());
+}
+
+void ut_bidirectional_list_multiple_insertions() {
+    BidirectionalList<Node> list;
+    Node node1(1), node2(2), node3(3);
+
+    // insert at back
+    list.push_back(node1);
+    list.push_back(node2);
+    list.push_back(node3);
+
+    TEST_ASSERT_FALSE(list.empty());
+    TEST_ASSERT_EQUAL_size_t(3, list.size());
+    TEST_ASSERT_EQUAL_INT(1, list.front().value());
+    TEST_ASSERT_EQUAL_INT(3, list.back().value());
+
+    // insert at front
+    Node node0(0);
+    list.push_front(node0);
+
+    TEST_ASSERT_EQUAL_size_t(4, list.size());
+    TEST_ASSERT_EQUAL_INT(0, list.front().value());
+    TEST_ASSERT_EQUAL_INT(3, list.back().value());
+}
+
+// verify insert_before / insert_after
+void ut_bidirectional_list_insert_before_after() {
+    BidirectionalList<Node> list;
+    Node node1(1), node2(2), node3(3), node4(4);
+
+    // start with node1 -> node3
+    list.push_back(node1);
+    list.push_back(node3);
+
+    // verify initial size / order
+    TEST_ASSERT_EQUAL_size_t(2, list.size());
+    {
+        auto it = list.begin();
+        TEST_ASSERT_EQUAL_INT(1, it->value());
+        ++it;
+        TEST_ASSERT_EQUAL_INT(3, it->value());
+    }
+
+    // insert node2 after node1
+    auto it = list.begin();
+    it = list.insert_after(it, node2);
+    TEST_ASSERT_EQUAL_size_t(3, list.size());
+
+    // verify order node1 -> node2 -> node3
+    {
+        auto iter = list.begin();
+        TEST_ASSERT_EQUAL_INT(1, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(2, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(3, iter->value());
+    }
+
+    // find node3
+    it = list.begin();
+    while (it != list.end() && it->value() != 3)
+        ++it;
+    TEST_ASSERT_TRUE(it != list.end());
+
+    // insert node4 before node3
+    it = list.insert_before(it, node4);
+    TEST_ASSERT_EQUAL_size_t(4, list.size());
+
+    // verify order node1 -> node2 -> node4 -> node3
+    {
+        auto iter = list.begin();
+        TEST_ASSERT_EQUAL_INT(1, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(2, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(4, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(3, iter->value());
+    }
+
+    // verify back returns node3
+    TEST_ASSERT_EQUAL_INT(3, list.back().value());
+
+    {
+        const std::vector<int> expected = {1, 2, 4, 3};
+        std::vector<int> actual;
+        for (auto iter = list.begin(); iter != list.end(); ++iter)
+            actual.push_back(iter->value());
+
+        for (size_t i = 0; i < expected.size(); ++i)
+            TEST_ASSERT_EQUAL_INT(expected[i], actual[i]);
+    }
+}
+
+// verify erase on head, middle, and tail
+void ut_bidirectional_link_erase() {
+    BidirectionalList<Node> list;
+    Node node1(1), node2(2), node3(3), node4(4);
+
+    // insert nodes: node1 <-> node2 <-> node3 <-> node4
+    list.push_back(node1);
+    list.push_back(node2);
+    list.push_back(node3);
+    list.push_back(node4);
+
+    // erase head
+    list.erase(list.begin());
+    TEST_ASSERT_EQUAL_size_t(3, list.size());
+    TEST_ASSERT_EQUAL_INT(2, list.front().value());
+
+    // verify order node2 <-> node3 <-> node4
+    {
+        auto iter = list.begin();
+        TEST_ASSERT_EQUAL_INT(2, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(3, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(4, iter->value());
+    }
+
+    // erase middle (node3)
+    auto it = list.begin();
+    ++it; // node3
+    list.erase(it);
+    TEST_ASSERT_EQUAL_size_t(2, list.size());
+
+    // verify order node2 <-> node4
+    {
+        auto iter = list.begin();
+        TEST_ASSERT_EQUAL_INT(2, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(4, iter->value());
+    }
+
+    // verify reverse order node4 <-> node2
+    {
+        auto iter = list.rbegin();
+        TEST_ASSERT_EQUAL_INT(4, iter->value());
+        ++iter;
+        TEST_ASSERT_EQUAL_INT(2, iter->value());
+    }
+
+    // erase tail
+    list.erase(&list.back());
+    TEST_ASSERT_EQUAL_size_t(1, list.size());
+    TEST_ASSERT_EQUAL_INT(2, list.front().value());
+    TEST_ASSERT_EQUAL_INT(2, list.back().value());
+}
+
+// verify pop_front / pop_back / erase
+void ut_bidirectional_list_removals() {
+    BidirectionalList<Node> list;
+    Node node1(1), node2(2), node3(3), node4(4);
+
+    list.push_back(node1);
+    list.push_back(node2);
+    list.push_back(node3);
+    list.push_back(node4);
+
+    // pop_front
+    list.pop_front();
+    TEST_ASSERT_EQUAL_size_t(3, list.size());
+    TEST_ASSERT_EQUAL_INT(2, list.front().value());
+
+    // pop_back
+    list.pop_back();
+    TEST_ASSERT_EQUAL_size_t(2, list.size());
+    TEST_ASSERT_EQUAL_INT(2, list.front().value());
+    TEST_ASSERT_EQUAL_INT(3, list.back().value());
+
+    // erase middle (node2)
+    auto it = list.begin();
+    it = list.erase(it);
+    TEST_ASSERT_EQUAL_size_t(1, list.size());
+    TEST_ASSERT_EQUAL_INT(3, list.front().value());
+    TEST_ASSERT_EQUAL_INT(3, list.back().value());
+}
+
+// verify forward / reverse iteration
+void ut_bidirectional_list_iteration() {
+    BidirectionalList<Node> list;
+    Node node1(1), node2(2), node3(3);
+
+    list.push_back(node1);
+    list.push_back(node2);
+    list.push_back(node3);
+
+    int expected_fwd[] = {1, 2, 3};
+    int idx = 0;
+    for (auto it = list.begin(); it != list.end(); ++it, ++idx)
+        TEST_ASSERT_EQUAL_INT(expected_fwd[idx], it->value());
+    TEST_ASSERT_EQUAL_INT(3, idx);
+
+    int expected_rev[] = {3, 2, 1};
+    idx = 0;
+    for (auto it = list.rbegin(); it != list.rend(); ++it, ++idx)
+        TEST_ASSERT_EQUAL_INT(expected_rev[idx], it->value());
+    TEST_ASSERT_EQUAL_INT(3, idx);
+}
+
+// verify reverse iterators collect correct values
+void ut_bidirectional_list_reverse_iterators() {
+    BidirectionalList<Node> list;
+    Node node1(1), node2(2), node3(3);
+
+    list.push_back(node1);
+    list.push_back(node2);
+    list.push_back(node3);
+
+    const std::vector<int> expected = {3, 2, 1};
+    std::vector<int> actual;
+    for (auto it = list.rbegin(); it != list.rend(); ++it)
+        actual.push_back(it->value());
+    TEST_ASSERT_EQUAL_INT_ARRAY(expected.data(), actual.data(), expected.size());
+}
+
+// verify depth helpers
+void ut_bidirectional_list_depth_calculations() {
+    BidirectionalList<Node> list;
+    Node node1(1), node2(2), node3(3), node4(4);
+
+    list.push_back(node1);
+    list.push_back(node2);
+    list.push_back(node3);
+    list.push_back(node4);
+
+    TEST_ASSERT_EQUAL_size_t(4, list.size());
+    TEST_ASSERT_EQUAL_size_t(4, list.front().depth_to_back());
+    TEST_ASSERT_EQUAL_size_t(4, list.back().depth_to_front());
+    TEST_ASSERT_EQUAL_size_t(3, node2.depth_to_back());
+    TEST_ASSERT_EQUAL_size_t(3, node3.depth_to_front());
+}
+
+// verify front / back helpers
+void ut_bidirectional_list_front_back() {
+    BidirectionalList<Node> list;
+    Node node1(1), node2(2), node3(3), node4(4);
+
+    // push_back nodes
+    list.push_back(node1);
+    list.push_back(node2);
+    list.push_back(node3);
+    list.push_back(node4);
+
+    TEST_ASSERT_EQUAL_INT(1, list.front().value());
+    TEST_ASSERT_EQUAL_INT(4, list.back().value());
+
+    // pop_front
+    list.pop_front();
+    TEST_ASSERT_EQUAL_INT(2, list.front().value());
+    TEST_ASSERT_EQUAL_INT(4, list.back().value());
+
+    // pop_back
+    list.pop_back();
+    TEST_ASSERT_EQUAL_INT(2, list.front().value());
+    TEST_ASSERT_EQUAL_INT(3, list.back().value());
+}
+
+// verify duplicate insert ignored
+void ut_bidirectional_list_edge_cases() {
+    BidirectionalList<Node> list;
+    Node node1(1);
+
+    list.push_back(node1);
+    TEST_ASSERT_EQUAL_size_t(1, list.size());
+
+    // attempt duplicate insert
+    list.push_back(node1);
+    TEST_ASSERT_EQUAL_size_t(1, list.size());
+    TEST_ASSERT_EQUAL_INT(1, list.front().value());
+    TEST_ASSERT_EQUAL_INT(1, list.back().value());
+
+    list.pop_back();
+    TEST_ASSERT_TRUE(list.empty());
+}
+
+// verify erase returns next iterator
+void ut_bidirectional_list_erase_return_value() {
+    BidirectionalList<Node> list;
+    Node a(1), b(2), c(3);
+    list.push_back(a);
+    list.push_back(b);
+    list.push_back(c);
+
+    auto next = list.erase(++list.begin()); // remove b
+    TEST_ASSERT_EQUAL_PTR(&c, &*next);
+}
+
+// verify move assignment
+void ut_bidirectional_list_move_assignment() {
+    BidirectionalList<Node> src;
+    Node a(1);
+    src.push_back(a);
+
+    BidirectionalList<Node> dst;
+    dst = std::move(src);
+
+    TEST_ASSERT_TRUE(src.empty());
+    TEST_ASSERT_FALSE(dst.empty());
+    TEST_ASSERT_EQUAL_INT(1, dst.front().value());
+}
+
+// verify external unlink of tail updates list
+void ut_bidirectional_list_external_unlink_tail() {
+    BidirectionalList<Node> list;
+    Node a(1), b(2);
+    list.push_back(a);
+    list.push_back(b);
+
+    b.unlink(); // external detach tail
+
+    TEST_ASSERT_EQUAL_PTR(&a, &list.front());
+    TEST_ASSERT_EQUAL_PTR(&a, &list.back());
+
+    size_t cnt = 0;
+    for (auto& n : list)
+        ++cnt;
+    TEST_ASSERT_EQUAL_size_t(1, cnt);
+}
+
+// verify const iteration compile-time behavior
+void ut_bidirectional_list_const_iteration() {
+    BidirectionalList<Node> list;
+    Node a(1);
+    list.push_back(a);
+
+    const auto& clist = list;
+    for (const auto& n : clist)
+        TEST_ASSERT_EQUAL_INT(1, n.value());
+}
+
+// verify iterator navigation on empty list
+void ut_bidirectional_list_iterators_empty_list_navigation() {
+    BidirectionalList<Node> l;
+    auto fwd = l.end(); // --end on empty
+    --fwd;
+    TEST_ASSERT_TRUE(fwd == l.end());
+
+    auto rev = l.rend(); // ++rend on empty
+    ++rev;
+    TEST_ASSERT_TRUE(rev == l.rend());
+}
+
+// verify iterator / pointer comparators
+void ut_bidirectional_list_pointer_comparators() {
+    BidirectionalList<Node> l;
+    Node a(1);
+    l.push_back(a);
+
+    TEST_ASSERT_TRUE(l.begin() == &a);
+    TEST_ASSERT_TRUE(&a == l.begin());
+    TEST_ASSERT_FALSE(l.begin() != &a);
+}
+
+// verify erase return on head / tail
+void ut_bidirectional_list_erase_return_head_tail() {
+    BidirectionalList<Node> l;
+    Node a(1);
+    l.push_back(a);
+
+    auto it = l.erase(l.begin());
+    TEST_ASSERT_TRUE(it == l.end());
+    TEST_ASSERT_TRUE(l.empty());
+}
+
+// verify second unlink is safe
+void ut_bidirectional_list_double_unlink_head_and_tail() {
+    Node h(1), t(2);
+    h.attach_next(&t);
+    h.unlink(); // unlink head
+    h.unlink(); // second unlink must be safe
+    TEST_ASSERT_NULL(h.next());
+    TEST_ASSERT_EQUAL_PTR(&t, &t.leaf_front());
+}
+
+// verify ensure_detached moves node between lists
+void ut_bidirectional_list_cross_list_detach() {
+    BidirectionalList<Node> l1, l2;
+    Node a(1);
+    l1.push_back(a);
+    l2.push_back(a); // ensure_detached removes from l1
+
+    TEST_ASSERT_TRUE(l1.empty());
+    TEST_ASSERT_FALSE(l2.empty());
+}
+
+// verify move assign over existing contents
+void ut_bidirectional_list_move_assign_over_existing() {
+    BidirectionalList<Node> src;
+    Node a(1), b(2);
+    src.push_back(a);
+    src.push_back(b);
+
+    BidirectionalList<Node> dst;
+    Node x(9);
+    dst.push_back(x); // dst not empty
+
+    dst = std::move(src);
+    TEST_ASSERT_EQUAL_size_t(2, dst.size());
+    TEST_ASSERT_TRUE(src.empty());
+    TEST_ASSERT_EQUAL_INT(1, dst.front().value());
+    TEST_ASSERT_EQUAL_INT(2, dst.back().value());
+}
+
+// verify erasure doesnt interfere with iteration
+void ut_bidirectional_list_iterator_erase_while_iterating() {
+    BidirectionalList<Node> l;
+    Node a(1), b(2), c(3);
+    l.push_back(a);
+    l.push_back(b);
+    l.push_back(c);
+
+    size_t n = 0;
+    for (auto it = l.begin(); it != l.end(); /* erase returns next */)
+        it = l.erase(it), ++n;
+
+    TEST_ASSERT_EQUAL_size_t(3, n);
+    TEST_ASSERT_TRUE(l.empty());
+}
+
+// verify forward iteration properly terminates
+void ut_bidirectional_list_iterator_forward_terminates() {
+    BidirectionalList<Node> l;
+    Node a(1), b(2), c(3);
+    l.push_back(a);
+    l.push_back(b);
+    l.push_back(c);
+
+    size_t steps = 0;
+    for (auto it = l.begin(); it != l.end(); ++it) {
+        ++steps;
+        if (steps > 10) TEST_FAIL_MESSAGE("forward iteration never reached end()");
+    }
+    TEST_ASSERT_EQUAL_size_t(3, steps);
+}
+
+// verify reverse iteration properly terminates
+void ut_bidirectional_list_iterator_reverse_terminates() {
+    BidirectionalList<Node> l;
+    Node a(1), b(2), c(3);
+    l.push_back(a);
+    l.push_back(b);
+    l.push_back(c);
+
+    size_t steps = 0;
+    for (auto it = l.rbegin(); it != l.rend(); ++it) {
+        ++steps;
+        if (steps > 10) TEST_FAIL_MESSAGE("reverse iteration never reached rend()");
+    }
+    TEST_ASSERT_EQUAL_size_t(3, steps);
+}
+
+// verify no endless loop is created when wrongly over increasing iterator
+void ut_bidirectional_list_increment_end_no_reentry() {
+    BidirectionalList<Node> l;
+    Node a(1);
+    l.push_back(a);
+
+    auto it = l.end();
+    for (int i = 0; i < 3; ++i)
+        ++it; // must stay at end()
+    TEST_ASSERT_TRUE(it == l.end());
+}
+
+// verify no endless loop is created when wrongly over decreasing iterator
+void ut_bidirectional_list_decrement_begin_no_reentry() {
+    BidirectionalList<Node> l;
+    Node a(1);
+    l.push_back(a);
+
+    auto it = l.begin();
+    for (int i = 0; i < 3; ++i)
+        --it;
+    TEST_ASSERT_TRUE(it == l.begin());
+}
+
+// verify external unlinking of head doesnt break list
+void ut_bidirectional_list_external_unlink_head_and_middle() {
+    BidirectionalList<Node> l;
+    Node a(1), b(2), c(3);
+    l.push_back(a);
+    l.push_back(b);
+    l.push_back(c);
+
+    a.unlink(); // unlink original head
+    TEST_ASSERT_EQUAL_size_t(2, l.size());
+    TEST_ASSERT_EQUAL_PTR(&b, &l.front());
+    TEST_ASSERT_EQUAL_PTR(&c, &l.back());
+
+    b.unlink(); // unlink new head / middle
+    TEST_ASSERT_EQUAL_size_t(1, l.size());
+    TEST_ASSERT_EQUAL_PTR(&c, &l.front());
+    TEST_ASSERT_EQUAL_PTR(&c, &l.back());
+}
+
+// verify linking and relinking to different list works properly
+void ut_bidirectional_list_cross_list_detach_middle() {
+    BidirectionalList<Node> l1, l2;
+    Node a(1), b(2), c(3);
+    l1.push_back(a);
+    l1.push_back(b);
+    l1.push_back(c);
+
+    l2.push_back(b); // ensure_detached must remove from l1
+
+    TEST_ASSERT_EQUAL_size_t(2, l1.size());
+    TEST_ASSERT_EQUAL_size_t(1, l2.size());
+    TEST_ASSERT_EQUAL_PTR(&a, &l1.front());
+    TEST_ASSERT_EQUAL_PTR(&c, &l1.back());
+    TEST_ASSERT_EQUAL_PTR(&b, &l2.front());
+}
+
+// verify inserting at leafs behaves like push front/back
+void ut_bidirectional_list_insert_before_end_after_rend() {
+    BidirectionalList<Node> l;
+    Node a(1), b(2), c(3);
+
+    l.push_back(a);
+    l.insert_before(l.end(), b); // should behave like push_back
+    l.insert_after(l.rend(), c); // should behave like push_front
+
+    TEST_ASSERT_EQUAL_size_t(3, l.size());
+    TEST_ASSERT_EQUAL_INT(3, l.front().value());
+    TEST_ASSERT_EQUAL_INT(2, l.back().value());
+}
+
+} // namespace
+
+int run_all_tests() {
+    UNITY_BEGIN();
+
+    RUN_TEST(ut_bidirectional_link_pointers);
+    RUN_TEST(ut_bidirectional_link_attach_prev_next);
+    RUN_TEST(ut_bidirectional_link_unlink);
+    RUN_TEST(ut_bidirectional_link_leaf_accessors);
+    RUN_TEST(ut_bidirectional_list_initialization);
+    RUN_TEST(ut_bidirectional_list_constructors);
+    RUN_TEST(ut_bidirectional_list_copy_constructor);
+    RUN_TEST(ut_bidirectional_list_single_insertion);
+    RUN_TEST(ut_bidirectional_list_multiple_insertions);
+    RUN_TEST(ut_bidirectional_list_insert_before_after);
+    RUN_TEST(ut_bidirectional_link_erase);
+    RUN_TEST(ut_bidirectional_list_removals);
+    RUN_TEST(ut_bidirectional_list_iteration);
+    RUN_TEST(ut_bidirectional_list_reverse_iterators);
+    RUN_TEST(ut_bidirectional_list_depth_calculations);
+    RUN_TEST(ut_bidirectional_list_front_back);
+    RUN_TEST(ut_bidirectional_list_edge_cases);
+    RUN_TEST(ut_bidirectional_list_erase_return_value);
+    RUN_TEST(ut_bidirectional_list_move_assignment);
+    RUN_TEST(ut_bidirectional_list_external_unlink_tail);
+    RUN_TEST(ut_bidirectional_list_const_iteration);
+    RUN_TEST(ut_bidirectional_list_iterators_empty_list_navigation);
+    RUN_TEST(ut_bidirectional_list_pointer_comparators);
+    RUN_TEST(ut_bidirectional_list_erase_return_head_tail);
+    RUN_TEST(ut_bidirectional_list_double_unlink_head_and_tail);
+    RUN_TEST(ut_bidirectional_list_cross_list_detach);
+    RUN_TEST(ut_bidirectional_list_move_assign_over_existing);
+    RUN_TEST(ut_bidirectional_list_iterator_erase_while_iterating);
+    RUN_TEST(ut_bidirectional_list_iterator_forward_terminates);
+    RUN_TEST(ut_bidirectional_list_iterator_reverse_terminates);
+    RUN_TEST(ut_bidirectional_list_increment_end_no_reentry);
+    RUN_TEST(ut_bidirectional_list_decrement_begin_no_reentry);
+    RUN_TEST(ut_bidirectional_list_external_unlink_head_and_middle);
+    RUN_TEST(ut_bidirectional_list_cross_list_detach_middle);
+    RUN_TEST(ut_bidirectional_list_insert_before_end_after_rend);
+
+    return UNITY_END();
+}
+
+#if defined(ARDUINO)
+#    include <Arduino.h>
+void setup() {
+    // wait >2 s if board lacks DTR/RTS reset
+    delay(2000);
+    run_all_tests();
+}
+
+void loop() {}
+#else
+int main(int, char**) { return run_all_tests(); }
+#endif


### PR DESCRIPTION
- Adds container BidirectionalList<T> with corresponding BidirectionalLink<T> which provide an easy way to order structures of arbitrary length without interfering with lifetime.

  Notes:
   - The primary goal of this container is to provide easy reordering with shallow copying (only the prev/next ptr's are updated).
   - Lifetime of the elements are by design not guaranteed by the List (as is the case for ETL::list)